### PR TITLE
[codex] Add local goal profile store

### DIFF
--- a/src/goals/goalProfile.ts
+++ b/src/goals/goalProfile.ts
@@ -1,0 +1,167 @@
+export type PrimaryGoal =
+  | 'general_fitness'
+  | 'body_composition'
+  | 'strength'
+  | 'endurance'
+  | 'event_preparation'
+  | 'return_to_training'
+  | 'health_and_energy'
+  | 'unknown';
+
+export type ExperienceLevel =
+  | 'first_time'
+  | 'returning_after_gap'
+  | 'inconsistent'
+  | 'recreational'
+  | 'advanced'
+  | 'unknown';
+
+export type CoachingStyle =
+  | 'supportive'
+  | 'direct'
+  | 'educational'
+  | 'minimal'
+  | 'unknown';
+
+export type StartingStrategy =
+  | 'baseline'
+  | 'conservative_build'
+  | 'maintain'
+  | 'event_phases'
+  | 'unknown';
+
+export type GoalProfile = {
+  primaryGoal: PrimaryGoal;
+  secondaryGoals: PrimaryGoal[];
+  motivation: string | null;
+  timeframe: string | null;
+  experienceLevel: ExperienceLevel;
+  preferredActivities: string[];
+  dislikedActivities: string[];
+  constraints: string[];
+  riskFlags: string[];
+  coachingStyle: CoachingStyle;
+  startingStrategy: StartingStrategy;
+  confidence: number;
+  updatedAt: string;
+};
+
+export type GoalProfileDraft = Partial<Omit<GoalProfile, 'updatedAt'>>;
+
+export const emptyGoalProfile: GoalProfile = {
+  primaryGoal: 'unknown',
+  secondaryGoals: [],
+  motivation: null,
+  timeframe: null,
+  experienceLevel: 'unknown',
+  preferredActivities: [],
+  dislikedActivities: [],
+  constraints: [],
+  riskFlags: [],
+  coachingStyle: 'unknown',
+  startingStrategy: 'unknown',
+  confidence: 0,
+  updatedAt: '',
+};
+
+const primaryGoals = new Set<PrimaryGoal>([
+  'general_fitness',
+  'body_composition',
+  'strength',
+  'endurance',
+  'event_preparation',
+  'return_to_training',
+  'health_and_energy',
+  'unknown',
+]);
+
+const experienceLevels = new Set<ExperienceLevel>([
+  'first_time',
+  'returning_after_gap',
+  'inconsistent',
+  'recreational',
+  'advanced',
+  'unknown',
+]);
+
+const coachingStyles = new Set<CoachingStyle>([
+  'supportive',
+  'direct',
+  'educational',
+  'minimal',
+  'unknown',
+]);
+
+const startingStrategies = new Set<StartingStrategy>([
+  'baseline',
+  'conservative_build',
+  'maintain',
+  'event_phases',
+  'unknown',
+]);
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean);
+}
+
+function numberInRange(value: unknown): number {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, number));
+}
+
+function primaryGoal(value: unknown): PrimaryGoal {
+  return primaryGoals.has(value as PrimaryGoal) ? (value as PrimaryGoal) : 'unknown';
+}
+
+function experienceLevel(value: unknown): ExperienceLevel {
+  return experienceLevels.has(value as ExperienceLevel)
+    ? (value as ExperienceLevel)
+    : 'unknown';
+}
+
+function coachingStyle(value: unknown): CoachingStyle {
+  return coachingStyles.has(value as CoachingStyle)
+    ? (value as CoachingStyle)
+    : 'unknown';
+}
+
+function startingStrategy(value: unknown): StartingStrategy {
+  return startingStrategies.has(value as StartingStrategy)
+    ? (value as StartingStrategy)
+    : 'unknown';
+}
+
+export function normalizeGoalProfile(
+  draft: GoalProfileDraft,
+  updatedAt = new Date().toISOString(),
+): GoalProfile {
+  return {
+    primaryGoal: primaryGoal(draft.primaryGoal),
+    secondaryGoals: stringArray(draft.secondaryGoals).map(primaryGoal),
+    motivation: stringOrNull(draft.motivation),
+    timeframe: stringOrNull(draft.timeframe),
+    experienceLevel: experienceLevel(draft.experienceLevel),
+    preferredActivities: stringArray(draft.preferredActivities),
+    dislikedActivities: stringArray(draft.dislikedActivities),
+    constraints: stringArray(draft.constraints),
+    riskFlags: stringArray(draft.riskFlags),
+    coachingStyle: coachingStyle(draft.coachingStyle),
+    startingStrategy: startingStrategy(draft.startingStrategy),
+    confidence: numberInRange(draft.confidence),
+    updatedAt,
+  };
+}

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -2,6 +2,15 @@ import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import * as SQLite from 'expo-sqlite';
 
+import {
+  normalizeGoalProfile,
+  type CoachingStyle,
+  type ExperienceLevel,
+  type GoalProfile,
+  type GoalProfileDraft,
+  type PrimaryGoal,
+  type StartingStrategy,
+} from '../goals/goalProfile';
 import { formatDuration, localDateKey } from '../lib/dates';
 import { safeJsonStringify } from '../lib/json';
 import type {
@@ -203,6 +212,23 @@ type DailyMetricsRow = {
   generated_at: string;
 };
 
+type GoalProfileRow = {
+  id: 'current';
+  primary_goal: PrimaryGoal;
+  secondary_goals_json: string;
+  motivation: string | null;
+  timeframe: string | null;
+  experience_level: ExperienceLevel;
+  preferred_activities_json: string;
+  disliked_activities_json: string;
+  constraints_json: string;
+  risk_flags_json: string;
+  coaching_style: CoachingStyle;
+  starting_strategy: StartingStrategy;
+  confidence: number;
+  updated_at: string;
+};
+
 export type CoachHealthContext = {
   generatedAt: string;
   hasSyncedHealthData: boolean;
@@ -355,6 +381,21 @@ function bool(value: number | null | undefined): boolean {
 
 function optionalNumber(value: number | null | undefined): number | undefined {
   return value == null ? undefined : Number(value);
+}
+
+function parseJsonStringArray(value: string | null | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 function numberOrZero(value: number | null | undefined): number {
@@ -891,6 +932,26 @@ function toDailyMetrics(row: DailyMetricsRow): DailyMetrics {
   };
 }
 
+function toGoalProfile(row: GoalProfileRow): GoalProfile {
+  return normalizeGoalProfile(
+    {
+      primaryGoal: row.primary_goal,
+      secondaryGoals: parseJsonStringArray(row.secondary_goals_json) as PrimaryGoal[],
+      motivation: row.motivation,
+      timeframe: row.timeframe,
+      experienceLevel: row.experience_level,
+      preferredActivities: parseJsonStringArray(row.preferred_activities_json),
+      dislikedActivities: parseJsonStringArray(row.disliked_activities_json),
+      constraints: parseJsonStringArray(row.constraints_json),
+      riskFlags: parseJsonStringArray(row.risk_flags_json),
+      coachingStyle: row.coaching_style,
+      startingStrategy: row.starting_strategy,
+      confidence: row.confidence,
+    },
+    row.updated_at,
+  );
+}
+
 async function getDb(): Promise<SQLite.SQLiteDatabase> {
   if (!dbPromise) {
     dbPromise = SQLite.openDatabaseAsync('training_pipeline.db').then(async (db) => {
@@ -1079,6 +1140,23 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_health_connect_diagnostics_started
       ON health_connect_diagnostics(sync_started_at);
+
+    CREATE TABLE IF NOT EXISTS goal_profile (
+      id TEXT PRIMARY KEY NOT NULL CHECK (id = 'current'),
+      primary_goal TEXT NOT NULL,
+      secondary_goals_json TEXT NOT NULL,
+      motivation TEXT,
+      timeframe TEXT,
+      experience_level TEXT NOT NULL,
+      preferred_activities_json TEXT NOT NULL,
+      disliked_activities_json TEXT NOT NULL,
+      constraints_json TEXT NOT NULL,
+      risk_flags_json TEXT NOT NULL,
+      coaching_style TEXT NOT NULL,
+      starting_strategy TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      updated_at TEXT NOT NULL
+    );
   `);
 
   const legacyColumns = await db.getAllAsync<{ name: string }>(
@@ -1113,6 +1191,59 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
 
 export async function initTrainingStore(): Promise<void> {
   await getDb();
+}
+
+export async function getGoalProfile(): Promise<GoalProfile | null> {
+  const db = await getDb();
+  const row = await db.getFirstAsync<GoalProfileRow>(
+    "SELECT * FROM goal_profile WHERE id = 'current' LIMIT 1",
+  );
+
+  return row ? toGoalProfile(row) : null;
+}
+
+export async function saveGoalProfile(draft: GoalProfileDraft): Promise<GoalProfile> {
+  const db = await getDb();
+  const current = await getGoalProfile();
+  const next = normalizeGoalProfile(
+    {
+      ...(current ?? {}),
+      ...draft,
+    },
+    new Date().toISOString(),
+  );
+
+  await db.runAsync(
+    `
+      INSERT OR REPLACE INTO goal_profile (
+        id, primary_goal, secondary_goals_json, motivation, timeframe,
+        experience_level, preferred_activities_json, disliked_activities_json,
+        constraints_json, risk_flags_json, coaching_style, starting_strategy,
+        confidence, updated_at
+      )
+      VALUES ('current', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    next.primaryGoal,
+    safeJsonStringify(next.secondaryGoals),
+    next.motivation,
+    next.timeframe,
+    next.experienceLevel,
+    safeJsonStringify(next.preferredActivities),
+    safeJsonStringify(next.dislikedActivities),
+    safeJsonStringify(next.constraints),
+    safeJsonStringify(next.riskFlags),
+    next.coachingStyle,
+    next.startingStrategy,
+    next.confidence,
+    next.updatedAt,
+  );
+
+  return next;
+}
+
+export async function clearGoalProfile(): Promise<void> {
+  const db = await getDb();
+  await db.runAsync("DELETE FROM goal_profile WHERE id = 'current'");
 }
 
 function isHealthConnectDailyAggregate(sample: HealthSample): boolean {
@@ -2126,6 +2257,7 @@ export async function exportPipelineJson(): Promise<string> {
     syncRuns,
     diagnostics,
     sourceFreshness,
+    goalProfileRow,
   ] =
     await Promise.all([
       db.getAllAsync<HealthSampleRow>('SELECT * FROM health_samples ORDER BY start_at ASC'),
@@ -2136,6 +2268,7 @@ export async function exportPipelineJson(): Promise<string> {
       db.getAllAsync<SyncRunRow>('SELECT * FROM sync_runs ORDER BY started_at ASC'),
       db.getAllAsync('SELECT * FROM health_connect_diagnostics ORDER BY sync_started_at ASC'),
       getSourceFreshness(db),
+      db.getFirstAsync<GoalProfileRow>("SELECT * FROM goal_profile WHERE id = 'current' LIMIT 1"),
     ]);
 
   const payload = {
@@ -2149,6 +2282,7 @@ export async function exportPipelineJson(): Promise<string> {
     sourceFreshness,
     syncRuns,
     diagnostics,
+    goalProfile: goalProfileRow ? toGoalProfile(goalProfileRow) : null,
   };
 
   const directory = FileSystem.documentDirectory;

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -9,6 +9,11 @@ import type {
   SyncPayload,
   SyncRange,
 } from '../health/types';
+import {
+  normalizeGoalProfile,
+  type GoalProfile,
+  type GoalProfileDraft,
+} from '../goals/goalProfile';
 
 export type HealthSampleRow = {
   sample_id: string;
@@ -347,7 +352,38 @@ let lastSync: SyncRunRow | null = {
   error: null,
 };
 
+let goalProfile: GoalProfile | null = normalizeGoalProfile({
+  primaryGoal: 'endurance',
+  secondaryGoals: ['strength'],
+  motivation: 'Build toward a confident half marathon block without overreaching.',
+  timeframe: '12 weeks',
+  experienceLevel: 'recreational',
+  preferredActivities: ['run', 'strength', 'walk'],
+  dislikedActivities: [],
+  constraints: ['protect recovery', 'avoid sudden volume jumps'],
+  riskFlags: [],
+  coachingStyle: 'supportive',
+  startingStrategy: 'conservative_build',
+  confidence: 0.74,
+});
+
 export async function initTrainingStore(): Promise<void> {}
+
+export async function getGoalProfile(): Promise<GoalProfile | null> {
+  return goalProfile;
+}
+
+export async function saveGoalProfile(draft: GoalProfileDraft): Promise<GoalProfile> {
+  goalProfile = normalizeGoalProfile({
+    ...(goalProfile ?? {}),
+    ...draft,
+  });
+  return goalProfile;
+}
+
+export async function clearGoalProfile(): Promise<void> {
+  goalProfile = null;
+}
 
 export async function upsertSyncPayload(payload: SyncPayload): Promise<number> {
   return (


### PR DESCRIPTION
## Summary

Starts Workstream C on an isolated fork branch by landing the foundation for #22, the local goal profile store.

Closes none yet; addresses the storage contract for #22.

## What changed

- Added typed `GoalProfile` / `GoalProfileDraft` contracts under `src/goals/goalProfile.ts`.
- Added normalization so unknown fields are explicit as `unknown`, `null`, empty arrays, or bounded confidence values.
- Added native SQLite helpers: `getGoalProfile`, `saveGoalProfile`, and `clearGoalProfile`.
- Added the singleton `goal_profile` SQLite table to the training store schema.
- Included the current goal profile in pipeline JSON export.
- Mirrored the same helpers in the Expo web demo adapter so browser development still works.

## Validation

- `npm run typecheck`
- `node UI\\BioStream\\coach-engine.test.cjs`

## Notes

This branch is pushed to the personal fork remote, not the shared repo remote, so it does not affect upstream `main` or other forks until reviewed and merged.
