### PR TITLE
[codex] Add training store rollup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build/
 coverage/
 web-build/
+.tmp/
 expo-env.d.ts
 
 # React Native / Expo

--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ The app uses Jest with the Expo preset so data, coach, and UI work can share one
 ```sh
 npm test
 npm run test:watch
+npm run test:rollups
 npm run test:ci
 npm run typecheck
 ```
 
-Place app tests under `src/` using `*.test.ts` or `*.test.tsx`. Prefer pure TypeScript tests for data and coach logic, and React Native Testing Library for component behavior.
+Place app tests under `src/` using `*.test.ts` or `*.test.tsx`. Prefer pure TypeScript tests for data and coach logic, React Native Testing Library for component behavior, and `npm run test:rollups` for the platform-neutral daily rollup and legacy migration fixtures.
 
 ## Native Notes
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prebuild": "expo prebuild",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:ci": "jest --runInBand",
+    "test:ci": "jest --runInBand && npm run test:rollups",
+    "test:rollups": "tsc -p tsconfig.test.json && node --test src/storage/trainingStoreRules.test.cjs",
     "typecheck": "tsc --noEmit",
     "web": "expo start --web"
   },

--- a/src/storage/fixtures/training-rollup.fixtures.json
+++ b/src/storage/fixtures/training-rollup.fixtures.json
@@ -1,0 +1,117 @@
+{
+  "today": "2026-04-29",
+  "generatedAt": "2026-04-29T12:00:00.000Z",
+  "healthSamples": [
+    {
+      "sampleId": "steps-full-1",
+      "canonicalType": "steps",
+      "localDate": "2026-04-28",
+      "value": 8200
+    },
+    {
+      "sampleId": "active-full-1",
+      "canonicalType": "active_energy",
+      "localDate": "2026-04-28",
+      "value": 540
+    },
+    {
+      "sampleId": "total-full-1",
+      "canonicalType": "total_energy",
+      "localDate": "2026-04-28",
+      "value": 2380
+    },
+    {
+      "sampleId": "distance-full-1",
+      "canonicalType": "distance",
+      "localDate": "2026-04-28",
+      "value": 6400
+    },
+    {
+      "sampleId": "resting-full-1",
+      "canonicalType": "resting_heart_rate",
+      "localDate": "2026-04-28",
+      "value": 51
+    },
+    {
+      "sampleId": "hrv-full-1",
+      "canonicalType": "hrv_rmssd",
+      "localDate": "2026-04-28",
+      "value": 62
+    },
+    {
+      "sampleId": "heart-full-1",
+      "canonicalType": "heart_rate",
+      "localDate": "2026-04-28",
+      "value": 58
+    },
+    {
+      "sampleId": "heart-full-2",
+      "canonicalType": "heart_rate",
+      "localDate": "2026-04-28",
+      "value": 104
+    },
+    {
+      "sampleId": "weight-full-1",
+      "canonicalType": "weight",
+      "localDate": "2026-04-28",
+      "value": 78.4
+    },
+    {
+      "sampleId": "steps-partial-1",
+      "canonicalType": "steps",
+      "localDate": "2026-04-27",
+      "value": 3100
+    }
+  ],
+  "sleepSessions": [
+    {
+      "sleepId": "sleep-wake-full",
+      "startAt": "2026-04-27T22:35:00+10:00",
+      "endAt": "2026-04-28T06:45:00+10:00",
+      "wakeDate": "2026-04-28",
+      "sleepSeconds": 25200,
+      "timeInBedSeconds": 29400,
+      "sleepEfficiency": 0.857
+    }
+  ],
+  "workouts": [
+    {
+      "workoutId": "run-full-1",
+      "localDate": "2026-04-28",
+      "sportBucket": "run",
+      "elapsedSeconds": 2700,
+      "activeKcal": 410
+    }
+  ],
+  "nutritionDaily": [
+    {
+      "date": "2026-04-28",
+      "kcalIn": 2210,
+      "proteinG": 132,
+      "carbsG": 245,
+      "fatG": 74,
+      "fiberG": 28,
+      "sugarG": 46,
+      "waterMl": 2600
+    },
+    {
+      "date": "2026-04-27",
+      "waterMl": 1200
+    }
+  ],
+  "legacyHealthSamples": [
+    {
+      "id": "legacy-steps-1",
+      "provider": "apple_health",
+      "metric": "steps",
+      "source_name": "Apple Health",
+      "source_id": "iphone",
+      "start_time": "2026-04-28T10:15:00+10:00",
+      "end_time": "2026-04-28T10:30:00+10:00",
+      "value": 900,
+      "unit": "count",
+      "raw_json": "{\"legacy\":true}",
+      "synced_at": "2026-04-29T00:00:00.000Z"
+    }
+  ]
+}

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -4,6 +4,11 @@ import * as SQLite from 'expo-sqlite';
 
 import { formatDuration, localDateKey } from '../lib/dates';
 import { safeJsonStringify } from '../lib/json';
+import {
+  buildDailyMetricsRollup,
+  normalizeLegacyHealthSampleRow,
+  type LegacyHealthSampleRow,
+} from './trainingStoreRules';
 import type {
   CanonicalType,
   CoachRecommendation,
@@ -1086,29 +1091,40 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
     'PRAGMA table_info(health_samples_legacy)',
   );
   if (legacyColumns.length) {
-    await db.execAsync(`
-      INSERT OR IGNORE INTO health_samples (
-        sample_id, platform, record_type, canonical_type, source_app, source_device,
-        start_at, end_at, local_date, value, unit, metadata_json, imported_at
-      )
+    const legacyRows = await db.getAllAsync<LegacyHealthSampleRow>(`
       SELECT
-        id,
-        CASE provider WHEN 'apple_health' THEN 'healthkit' ELSE provider END,
-        metric,
-        metric,
-        source_name,
-        source_id,
-        start_time,
-        end_time,
-        date(start_time, 'localtime'),
-        value,
-        unit,
-        raw_json,
-        synced_at
-      FROM health_samples_legacy;
-
-      DROP TABLE health_samples_legacy;
+        id, provider, metric, source_name, source_id, start_time, end_time,
+        value, unit, raw_json, synced_at
+      FROM health_samples_legacy
     `);
+
+    for (const row of legacyRows) {
+      const sample = normalizeLegacyHealthSampleRow(row);
+      await db.runAsync(
+        `
+          INSERT OR IGNORE INTO health_samples (
+            sample_id, platform, record_type, canonical_type, source_app, source_device,
+            start_at, end_at, local_date, value, unit, metadata_json, imported_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        sample.sampleId,
+        sample.platform,
+        sample.recordType,
+        sample.canonicalType,
+        sample.sourceApp,
+        sample.sourceDevice,
+        sample.startAt,
+        sample.endAt,
+        sample.localDate,
+        sample.value,
+        sample.unit,
+        sample.metadataJson,
+        sample.importedAt,
+      );
+    }
+
+    await db.execAsync('DROP TABLE health_samples_legacy;');
   }
 }
 
@@ -1551,27 +1567,51 @@ async function rebuildDailyMetrics(): Promise<void> {
       date,
     );
 
-    const sleepSeconds = sleep?.sleep_seconds ?? sleepFallback ?? null;
-    const timeInBedSeconds = sleep?.time_in_bed_seconds ?? sleepFallback ?? null;
-    const hasSleep = Boolean(sleepSeconds);
-    const hasActivity = Boolean(workout.workout_count);
-    const hasNutrition = Boolean(nutrition);
-    const hasSteps = steps != null;
-    const hasEnergy = activeKcal != null || totalKcal != null;
-    const hasVitals = Boolean(restingHr || hrv || heartRateAvg || weightKg || bodyFatPct);
-    const hasPlatformWellness = hasSleep || hasVitals;
-    const sourceCount = [
-      hasPlatformWellness,
-      hasActivity,
-      hasNutrition,
-      hasSteps,
-      hasEnergy,
-    ].filter(Boolean).length;
-    const dataCompleteness =
-      date === today ? 'partial' : sourceCount >= 4 ? 'full' : sourceCount > 0 ? 'partial' : 'empty';
-    const wellnessDataStatus = sourceCount
-      ? `Health Connect ${dataCompleteness}`
-      : 'No platform data';
+    const daily = buildDailyMetricsRollup({
+      date,
+      today,
+      generatedAt,
+      steps,
+      activeKcal,
+      totalKcal,
+      distanceMeters,
+      sleep: sleep
+        ? {
+            sleepSeconds: sleep.sleep_seconds ?? undefined,
+            timeInBedSeconds: sleep.time_in_bed_seconds ?? undefined,
+            sleepEfficiency: sleep.sleep_efficiency ?? undefined,
+          }
+        : null,
+      sleepFallbackSeconds: sleepFallback,
+      restingHr,
+      heartRateAvgBpm: heartRateAvg,
+      heartRateMinBpm: heartRateMin,
+      heartRateMaxBpm: heartRateMax,
+      hrvLastNightAvg: hrv,
+      workout: {
+        workoutCount: workout.workout_count,
+        runWorkoutCount: workout.run_workout_count,
+        rideWorkoutCount: workout.ride_workout_count,
+        strengthWorkoutCount: workout.strength_workout_count,
+        activityElapsedSeconds: workout.activity_elapsed_seconds ?? undefined,
+        activityKcal: workout.activity_kcal ?? undefined,
+      },
+      nutrition: nutrition
+        ? {
+            kcalIn: nutrition.kcal_in ?? undefined,
+            proteinG: nutrition.protein_g ?? undefined,
+            carbsG: nutrition.carbs_g ?? undefined,
+            fatG: nutrition.fat_g ?? undefined,
+            fiberG: nutrition.fiber_g ?? undefined,
+            sugarG: nutrition.sugar_g ?? undefined,
+            waterMl: nutrition.water_ml ?? undefined,
+          }
+        : null,
+      weightKg,
+      bodyFatPct,
+      leanBodyMassKg,
+      vo2max,
+    });
 
     await db.runAsync(
       `
@@ -1589,46 +1629,46 @@ async function rebuildDailyMetrics(): Promise<void> {
         )
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
-      date,
-      dataCompleteness,
-      wellnessDataStatus,
-      sourceCount,
-      hasPlatformWellness ? 1 : 0,
-      hasActivity ? 1 : 0,
-      hasNutrition ? 1 : 0,
-      hasSleep ? 1 : 0,
-      hasSteps ? 1 : 0,
-      hasEnergy ? 1 : 0,
-      steps ?? null,
-      activeKcal ?? null,
-      totalKcal ?? null,
-      distanceMeters == null ? null : distanceMeters / 1000,
-      sleepSeconds,
-      timeInBedSeconds,
-      sleep?.sleep_efficiency ?? null,
-      restingHr ?? null,
-      heartRateAvg ?? null,
-      heartRateMin ?? null,
-      heartRateMax ?? null,
-      hrv ?? null,
-      workout.workout_count,
-      workout.run_workout_count,
-      workout.ride_workout_count,
-      workout.strength_workout_count,
-      workout.activity_elapsed_seconds,
-      workout.activity_kcal,
-      nutrition?.kcal_in ?? null,
-      nutrition?.protein_g ?? null,
-      nutrition?.carbs_g ?? null,
-      nutrition?.fat_g ?? null,
-      nutrition?.fiber_g ?? null,
-      nutrition?.sugar_g ?? null,
-      nutrition?.water_ml ?? null,
-      weightKg ?? null,
-      bodyFatPct ?? null,
-      leanBodyMassKg ?? null,
-      vo2max ?? null,
-      generatedAt,
+      daily.date,
+      daily.dataCompleteness,
+      daily.wellnessDataStatus,
+      daily.sourceCount,
+      daily.hasPlatformWellness ? 1 : 0,
+      daily.hasActivity ? 1 : 0,
+      daily.hasNutrition ? 1 : 0,
+      daily.hasSleep ? 1 : 0,
+      daily.hasSteps ? 1 : 0,
+      daily.hasEnergy ? 1 : 0,
+      daily.steps ?? null,
+      daily.activeKcal ?? null,
+      daily.totalKcal ?? null,
+      daily.distanceKm ?? null,
+      daily.sleepSeconds ?? null,
+      daily.timeInBedSeconds ?? null,
+      daily.sleepEfficiency ?? null,
+      daily.restingHr ?? null,
+      daily.heartRateAvgBpm ?? null,
+      daily.heartRateMinBpm ?? null,
+      daily.heartRateMaxBpm ?? null,
+      daily.hrvLastNightAvg ?? null,
+      daily.workoutCount ?? null,
+      daily.runWorkoutCount ?? null,
+      daily.rideWorkoutCount ?? null,
+      daily.strengthWorkoutCount ?? null,
+      daily.activityElapsedSeconds ?? null,
+      daily.activityKcal ?? null,
+      daily.kcalIn ?? null,
+      daily.proteinG ?? null,
+      daily.carbsG ?? null,
+      daily.fatG ?? null,
+      daily.fiberG ?? null,
+      daily.sugarG ?? null,
+      daily.waterMl ?? null,
+      daily.weightKg ?? null,
+      daily.bodyFatPct ?? null,
+      daily.leanBodyMassKg ?? null,
+      daily.vo2max ?? null,
+      daily.generatedAt,
     );
   }
 }

--- a/src/storage/trainingStoreRules.test.cjs
+++ b/src/storage/trainingStoreRules.test.cjs
@@ -1,0 +1,156 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const path = require('node:path');
+
+const fixtures = require('./fixtures/training-rollup.fixtures.json');
+const {
+  buildDailyMetricsRollup,
+  normalizeLegacyHealthSampleRow,
+} = require(path.join(process.cwd(), '.tmp/test-build/src/storage/trainingStoreRules.js'));
+
+function valuesFor(date, canonicalType) {
+  return fixtures.healthSamples
+    .filter((sample) => sample.localDate === date && sample.canonicalType === canonicalType)
+    .map((sample) => sample.value)
+    .filter((value) => value != null);
+}
+
+function sumFor(date, canonicalType) {
+  const values = valuesFor(date, canonicalType);
+  return values.length ? values.reduce((sum, value) => sum + value, 0) : undefined;
+}
+
+function averageFor(date, canonicalType) {
+  const values = valuesFor(date, canonicalType);
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : undefined;
+}
+
+function minFor(date, canonicalType) {
+  const values = valuesFor(date, canonicalType);
+  return values.length ? Math.min(...values) : undefined;
+}
+
+function maxFor(date, canonicalType) {
+  const values = valuesFor(date, canonicalType);
+  return values.length ? Math.max(...values) : undefined;
+}
+
+function latestFor(date, canonicalType) {
+  const values = valuesFor(date, canonicalType);
+  return values.length ? values[values.length - 1] : undefined;
+}
+
+function workoutRollupFor(date) {
+  const workouts = fixtures.workouts.filter((workout) => workout.localDate === date);
+  const activeKcal = workouts.reduce((sum, workout) => sum + (workout.activeKcal ?? 0), 0);
+
+  return {
+    workoutCount: workouts.length,
+    runWorkoutCount: workouts.filter((workout) => workout.sportBucket === 'run').length,
+    rideWorkoutCount: workouts.filter((workout) => workout.sportBucket === 'ride').length,
+    strengthWorkoutCount: workouts.filter((workout) => workout.sportBucket === 'strength').length,
+    activityElapsedSeconds: workouts.length
+      ? workouts.reduce((sum, workout) => sum + workout.elapsedSeconds, 0)
+      : undefined,
+    activityKcal: activeKcal || undefined,
+  };
+}
+
+function nutritionFor(date) {
+  return fixtures.nutritionDaily.find((nutrition) => nutrition.date === date) ?? null;
+}
+
+function sleepForWakeDate(date) {
+  const sleep = fixtures.sleepSessions.find((session) => session.wakeDate === date);
+  return sleep
+    ? {
+        sleepSeconds: sleep.sleepSeconds,
+        timeInBedSeconds: sleep.timeInBedSeconds,
+        sleepEfficiency: sleep.sleepEfficiency,
+      }
+    : null;
+}
+
+function rollupFor(date, overrides = {}) {
+  return buildDailyMetricsRollup({
+    date,
+    today: fixtures.today,
+    generatedAt: fixtures.generatedAt,
+    steps: sumFor(date, 'steps'),
+    activeKcal: sumFor(date, 'active_energy'),
+    totalKcal: sumFor(date, 'total_energy'),
+    distanceMeters: sumFor(date, 'distance'),
+    sleep: sleepForWakeDate(date),
+    restingHr: averageFor(date, 'resting_heart_rate'),
+    heartRateAvgBpm: averageFor(date, 'heart_rate'),
+    heartRateMinBpm: minFor(date, 'heart_rate'),
+    heartRateMaxBpm: maxFor(date, 'heart_rate'),
+    hrvLastNightAvg: averageFor(date, 'hrv_rmssd'),
+    workout: workoutRollupFor(date),
+    nutrition: nutritionFor(date),
+    weightKg: latestFor(date, 'weight'),
+    ...overrides,
+  });
+}
+
+test('rolls up a full fixture day without assigning sleep to its start date', () => {
+  const wakeDay = rollupFor('2026-04-28');
+  const sleepStartDay = rollupFor('2026-04-27');
+
+  assert.equal(wakeDay.dataCompleteness, 'full');
+  assert.equal(wakeDay.sourceCount, 5);
+  assert.equal(wakeDay.hasSleep, true);
+  assert.equal(wakeDay.sleepSeconds, 25200);
+  assert.equal(wakeDay.distanceKm, 6.4);
+  assert.equal(wakeDay.workoutCount, 1);
+  assert.equal(wakeDay.kcalIn, 2210);
+
+  assert.equal(sleepStartDay.hasSleep, false);
+  assert.equal(sleepStartDay.sleepSeconds, undefined);
+});
+
+test('keeps partial days partial and does not coerce missing values to zero', () => {
+  const partialDay = rollupFor('2026-04-27');
+
+  assert.equal(partialDay.dataCompleteness, 'partial');
+  assert.equal(partialDay.sourceCount, 2);
+  assert.equal(partialDay.hasSteps, true);
+  assert.equal(partialDay.hasNutrition, true);
+  assert.equal(partialDay.hasEnergy, false);
+  assert.equal(partialDay.activeKcal, undefined);
+  assert.equal(partialDay.totalKcal, undefined);
+  assert.equal(partialDay.sleepSeconds, undefined);
+  assert.equal(partialDay.waterMl, 1200);
+});
+
+test('marks the current local day partial even when enough sources are present', () => {
+  const today = rollupFor(fixtures.today, {
+    steps: 9000,
+    activeKcal: 600,
+    totalKcal: 2400,
+    sleep: { sleepSeconds: 26000, timeInBedSeconds: 29000 },
+    workout: {
+      workoutCount: 1,
+      runWorkoutCount: 1,
+      rideWorkoutCount: 0,
+      strengthWorkoutCount: 0,
+    },
+    nutrition: { kcalIn: 2100, waterMl: 2400 },
+  });
+
+  assert.equal(today.sourceCount, 5);
+  assert.equal(today.dataCompleteness, 'partial');
+});
+
+test('normalizes supported legacy sample rows before migration insert', () => {
+  const sample = normalizeLegacyHealthSampleRow(fixtures.legacyHealthSamples[0]);
+
+  assert.equal(sample.sampleId, 'legacy-steps-1');
+  assert.equal(sample.platform, 'healthkit');
+  assert.equal(sample.recordType, 'steps');
+  assert.equal(sample.canonicalType, 'steps');
+  assert.equal(sample.localDate, '2026-04-28');
+  assert.equal(sample.sourceApp, 'Apple Health');
+  assert.equal(sample.sourceDevice, 'iphone');
+  assert.equal(sample.metadataJson, '{"legacy":true}');
+});

--- a/src/storage/trainingStoreRules.ts
+++ b/src/storage/trainingStoreRules.ts
@@ -1,0 +1,188 @@
+import { localDateKey } from '../lib/dates';
+import type { CanonicalType, DailyMetrics, HealthProvider } from '../health/types';
+
+export type DailyWorkoutRollup = {
+  workoutCount: number;
+  runWorkoutCount: number;
+  rideWorkoutCount: number;
+  strengthWorkoutCount: number;
+  activityElapsedSeconds?: number;
+  activityKcal?: number;
+};
+
+export type DailyNutritionRollup = {
+  kcalIn?: number;
+  proteinG?: number;
+  carbsG?: number;
+  fatG?: number;
+  fiberG?: number;
+  sugarG?: number;
+  waterMl?: number;
+};
+
+export type DailySleepRollup = {
+  sleepSeconds?: number;
+  timeInBedSeconds?: number;
+  sleepEfficiency?: number;
+};
+
+export type DailyMetricsRollupInput = {
+  date: string;
+  today: string;
+  generatedAt: string;
+  providerLabel?: string;
+  steps?: number;
+  activeKcal?: number;
+  totalKcal?: number;
+  distanceMeters?: number;
+  sleep?: DailySleepRollup | null;
+  sleepFallbackSeconds?: number;
+  restingHr?: number;
+  heartRateAvgBpm?: number;
+  heartRateMinBpm?: number;
+  heartRateMaxBpm?: number;
+  hrvLastNightAvg?: number;
+  workout: DailyWorkoutRollup;
+  nutrition?: DailyNutritionRollup | null;
+  weightKg?: number;
+  bodyFatPct?: number;
+  leanBodyMassKg?: number;
+  vo2max?: number;
+};
+
+export type LegacyHealthSampleRow = {
+  id: string;
+  provider: string;
+  metric: string;
+  source_name: string | null;
+  source_id: string | null;
+  start_time: string;
+  end_time: string;
+  value: number | null;
+  unit: string | null;
+  raw_json: string;
+  synced_at: string;
+};
+
+export type NormalizedLegacyHealthSample = {
+  sampleId: string;
+  platform: HealthProvider;
+  recordType: string;
+  canonicalType: CanonicalType;
+  sourceApp: string | null;
+  sourceDevice: string | null;
+  startAt: string;
+  endAt: string;
+  localDate: string;
+  value: number | null;
+  unit: string | null;
+  metadataJson: string;
+  importedAt: string;
+};
+
+function optionalNumber(value: number | null | undefined): number | undefined {
+  return value == null ? undefined : Number(value);
+}
+
+function hasValue(value: number | null | undefined): boolean {
+  return value != null;
+}
+
+export function buildDailyMetricsRollup(input: DailyMetricsRollupInput): DailyMetrics {
+  const sleepSeconds = input.sleep?.sleepSeconds ?? input.sleepFallbackSeconds;
+  const timeInBedSeconds = input.sleep?.timeInBedSeconds ?? input.sleepFallbackSeconds;
+  const hasSleep = hasValue(sleepSeconds);
+  const hasActivity = input.workout.workoutCount > 0;
+  const hasNutrition = Boolean(input.nutrition);
+  const hasSteps = hasValue(input.steps);
+  const hasEnergy = hasValue(input.activeKcal) || hasValue(input.totalKcal);
+  const hasVitals = [
+    input.restingHr,
+    input.hrvLastNightAvg,
+    input.heartRateAvgBpm,
+    input.weightKg,
+    input.bodyFatPct,
+  ].some(hasValue);
+  const hasPlatformWellness = hasSleep || hasVitals;
+  const sourceCount = [
+    hasPlatformWellness,
+    hasActivity,
+    hasNutrition,
+    hasSteps,
+    hasEnergy,
+  ].filter(Boolean).length;
+  const dataCompleteness =
+    input.date === input.today
+      ? 'partial'
+      : sourceCount >= 4
+        ? 'full'
+        : sourceCount > 0
+          ? 'partial'
+          : 'empty';
+  const wellnessDataStatus = sourceCount
+    ? `${input.providerLabel ?? 'Health Connect'} ${dataCompleteness}`
+    : 'No platform data';
+
+  return {
+    date: input.date,
+    dataCompleteness,
+    wellnessDataStatus,
+    sourceCount,
+    hasPlatformWellness,
+    hasActivity,
+    hasNutrition,
+    hasSleep,
+    hasSteps,
+    hasEnergy,
+    steps: optionalNumber(input.steps),
+    activeKcal: optionalNumber(input.activeKcal),
+    totalKcal: optionalNumber(input.totalKcal),
+    distanceKm: input.distanceMeters == null ? undefined : input.distanceMeters / 1000,
+    sleepSeconds: optionalNumber(sleepSeconds),
+    timeInBedSeconds: optionalNumber(timeInBedSeconds),
+    sleepEfficiency: optionalNumber(input.sleep?.sleepEfficiency),
+    restingHr: optionalNumber(input.restingHr),
+    heartRateAvgBpm: optionalNumber(input.heartRateAvgBpm),
+    heartRateMinBpm: optionalNumber(input.heartRateMinBpm),
+    heartRateMaxBpm: optionalNumber(input.heartRateMaxBpm),
+    hrvLastNightAvg: optionalNumber(input.hrvLastNightAvg),
+    workoutCount: input.workout.workoutCount,
+    runWorkoutCount: input.workout.runWorkoutCount,
+    rideWorkoutCount: input.workout.rideWorkoutCount,
+    strengthWorkoutCount: input.workout.strengthWorkoutCount,
+    activityElapsedSeconds: optionalNumber(input.workout.activityElapsedSeconds),
+    activityKcal: optionalNumber(input.workout.activityKcal),
+    kcalIn: optionalNumber(input.nutrition?.kcalIn),
+    proteinG: optionalNumber(input.nutrition?.proteinG),
+    carbsG: optionalNumber(input.nutrition?.carbsG),
+    fatG: optionalNumber(input.nutrition?.fatG),
+    fiberG: optionalNumber(input.nutrition?.fiberG),
+    sugarG: optionalNumber(input.nutrition?.sugarG),
+    waterMl: optionalNumber(input.nutrition?.waterMl),
+    weightKg: optionalNumber(input.weightKg),
+    bodyFatPct: optionalNumber(input.bodyFatPct),
+    leanBodyMassKg: optionalNumber(input.leanBodyMassKg),
+    vo2max: optionalNumber(input.vo2max),
+    generatedAt: input.generatedAt,
+  };
+}
+
+export function normalizeLegacyHealthSampleRow(
+  row: LegacyHealthSampleRow,
+): NormalizedLegacyHealthSample {
+  return {
+    sampleId: row.id,
+    platform: (row.provider === 'apple_health' ? 'healthkit' : row.provider) as HealthProvider,
+    recordType: row.metric,
+    canonicalType: row.metric as CanonicalType,
+    sourceApp: row.source_name,
+    sourceDevice: row.source_id,
+    startAt: row.start_time,
+    endAt: row.end_time,
+    localDate: localDateKey(row.start_time),
+    value: row.value,
+    unit: row.unit,
+    metadataJson: row.raw_json,
+    importedAt: row.synced_at,
+  };
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2020",
+    "outDir": ".tmp/test-build",
+    "rootDir": ".",
+    "noEmit": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/health/types.ts",
+    "src/lib/dates.ts",
+    "src/storage/trainingStoreRules.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a platform-neutral daily rollup helper so schema and completeness rules can be tested without native SQLite.
- Add fixtures and Node test coverage for full/partial days, wake-date sleep assignment, missing values, today-as-partial behavior, and legacy sample migration normalization.
- Wire the existing training store through the shared helper and include the rollup tests in `test:ci`.

Closes #7

## Verification
- npm run test:ci
- npm run typecheck
- git diff --check