### PR TITLE
[codex] Separate HRV methods in readiness

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,7 @@ import type {
   CanonicalType,
   DailyMetrics,
   HealthConnectReadDiagnostic,
+  HrvMethod,
   MetricAvailability,
   PipelineSnapshot,
   SourceFreshness,
@@ -179,7 +180,7 @@ const analyticsMetrics: AnalyticsMetricConfig[] = [
   {
     id: 'hrv',
     title: 'HRV',
-    detail: 'RMSSD or Apple SDNN',
+    detail: 'Method-specific RMSSD or SDNN',
     types: ['hrv_rmssd', 'hrv_sdnn'],
     icon: HeartPulse,
     gap: 'Connect a source that writes HRV to Health Connect or Apple Health.',
@@ -260,6 +261,17 @@ function formatNumber(value?: number, digits = 0): string {
   });
 }
 
+function hrvMethodLabel(method?: HrvMethod): string {
+  if (method === 'rmssd') return 'RMSSD';
+  if (method === 'sdnn') return 'SDNN';
+  return 'HRV';
+}
+
+function hrvMetricLabel(day?: DailyMetrics | null): string {
+  const method = hrvMethodLabel(day?.hrvMethod);
+  return day?.hrvLastNightAvg == null || method === 'HRV' ? 'HRV' : `HRV ${method}`;
+}
+
 function formatDateKey(date?: string): string {
   if (!date) {
     return formatDisplayDate(new Date());
@@ -275,7 +287,7 @@ function metricLabel(type: CanonicalType): string {
     distance: 'Distance',
     heart_rate: 'Heart rate',
     hydration: 'Hydration',
-    hrv_rmssd: 'HRV',
+    hrv_rmssd: 'HRV RMSSD',
     hrv_sdnn: 'HRV SDNN',
     lean_body_mass: 'Lean mass',
     nutrition: 'Nutrition',
@@ -555,6 +567,7 @@ function CoachScreen({
   const plan = useMemo(() => generateTrainingPlan(snapshot, 'run'), [snapshot]);
   const sleep = current?.sleepSeconds ? formatDuration(current.sleepSeconds) : '—';
   const hrv = current?.hrvLastNightAvg ? `${Math.round(current.hrvLastNightAvg)} ms` : '—';
+  const hrvLabel = hrvMetricLabel(current);
   const rhr = current?.restingHr ? `${Math.round(current.restingHr)} bpm` : '—';
   const quickReplies = ['Make it easier', 'Move it to tomorrow', "I'm short on time"];
   const canSendCoachMessage = hasOpenAiApiKey && !coachBusy && Boolean(coachDraft.trim());
@@ -620,7 +633,7 @@ function CoachScreen({
           <View style={styles.metricGridFull}>
             <SmallMetric label="Sleep" value={sleep} />
             <SmallMetric label="Score" value={formatNumber(recommendation.readiness ?? undefined)} />
-            <SmallMetric label="HRV" value={hrv.replace(' ms', '')} />
+            <SmallMetric label={hrvLabel} value={hrv.replace(' ms', '')} />
             <SmallMetric label="RHR" value={rhr.replace(' bpm', '')} />
           </View>
           <Text style={styles.helpText}>{recommendation.reason}</Text>
@@ -1076,12 +1089,34 @@ function WorkoutItem({ workout }: { workout: WorkoutRecord }) {
 }
 
 function SignalTrendChart({ history }: { history: DailyMetrics[] }) {
-  const values = history
-    .slice()
-    .reverse()
-    .slice(-7)
-    .map((day) => day.hrvLastNightAvg ?? day.restingHr ?? 0);
-  const labels = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const chronological = history.slice().reverse();
+  const hrvDays = chronological.filter((day) => day.hrvLastNightAvg != null);
+  const latestHrvDay = hrvDays[hrvDays.length - 1];
+  const compatibleDays = latestHrvDay
+    ? chronological.filter((day) => {
+        if (day.hrvLastNightAvg == null || day.hrvMethod !== latestHrvDay.hrvMethod) {
+          return false;
+        }
+        if (
+          day.hrvCanonicalType &&
+          latestHrvDay.hrvCanonicalType &&
+          day.hrvCanonicalType !== latestHrvDay.hrvCanonicalType
+        ) {
+          return false;
+        }
+
+        if (day.hrvSourceKey || latestHrvDay.hrvSourceKey) {
+          return day.hrvSourceKey === latestHrvDay.hrvSourceKey;
+        }
+
+        return true;
+      })
+    : [];
+  const chartDays = compatibleDays.slice(-7);
+  const values = chartDays.map((day) => day.hrvLastNightAvg ?? 0);
+  const labels = chartDays.map((day) =>
+    new Date(`${day.date}T12:00:00`).toLocaleDateString(undefined, { weekday: 'short' }).slice(0, 1),
+  );
   const max = Math.max(...values, 1);
   const min = Math.min(...values, 0);
   const range = max - min || 1;
@@ -1091,26 +1126,37 @@ function SignalTrendChart({ history }: { history: DailyMetrics[] }) {
     return [x, y];
   });
   const line = points.map(([x, y], index) => `${index === 0 ? 'M' : 'L'}${x},${y}`).join(' ');
+  const latestValue = values[values.length - 1];
+  const baselineValues = values.slice(0, -1);
+  const baseline = baselineValues.length
+    ? baselineValues.reduce((sum, value) => sum + value, 0) / baselineValues.length
+    : undefined;
+  const delta = latestValue != null && baseline != null ? latestValue - baseline : undefined;
+  const sectionTitle = `${hrvMetricLabel(latestHrvDay)} · 7-day`;
 
   return (
     <View style={styles.signalChart}>
       <View style={styles.signalChartHeader}>
         <View>
-          <SectionLabel>HRV · 7-day</SectionLabel>
+          <SectionLabel>{sectionTitle}</SectionLabel>
           <View style={styles.signalValueLine}>
-            <Text style={styles.signalValue}>{formatNumber(values[values.length - 1], 0)}</Text>
+            <Text style={styles.signalValue}>{formatNumber(latestValue, 0)}</Text>
             <Text style={styles.signalUnit}>ms</Text>
           </View>
         </View>
         <View style={styles.signalBaseline}>
           <Text style={styles.signalBaselineText}>vs baseline</Text>
-          <Text style={styles.signalDelta}>+2 ms</Text>
+          <Text style={styles.signalDelta}>
+            {delta == null ? '—' : `${delta > 0 ? '+' : ''}${formatNumber(delta, 0)} ms`}
+          </Text>
         </View>
       </View>
       <Svg height={150} width="100%" viewBox="0 0 300 150" preserveAspectRatio="none">
         <Rect fill={tokens.surfaceAlt} height={82} width={264} x={18} y={44} />
         <Path d="M18,86 L282,86" stroke={tokens.line} strokeDasharray="4 4" strokeWidth={1.4} />
-        <Path d={line} fill="none" stroke={tokens.cool} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.4} />
+        {line ? (
+          <Path d={line} fill="none" stroke={tokens.cool} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.4} />
+        ) : null}
         {points.map(([x, y], index) => (
           <Circle cx={x} cy={y} fill={tokens.cool} key={`${x}-${y}-${index}`} r={3} />
         ))}

--- a/src/ai/openaiCoach.ts
+++ b/src/ai/openaiCoach.ts
@@ -1,4 +1,4 @@
-import type { PipelineSnapshot } from '../health/types';
+import type { DailyMetrics, PipelineSnapshot } from '../health/types';
 import { formatDuration } from '../lib/dates';
 import type { CoachHealthContext } from '../storage/trainingStore';
 
@@ -33,6 +33,7 @@ const coachInstructions = [
   'Be conservative with pain, injury, illness, fever, chest pain, fainting, unusual shortness of breath, or severe fatigue. In those cases lower intensity and suggest professional care when symptoms are serious, sharp, worsening, chest-related, or unusual.',
   'Do not diagnose, prescribe treatment, or make emergency claims. Separate what the data supports from what remains uncertain.',
   'When data is stale or missing, say so plainly and use a safer recommendation.',
+  'Never compare HRV values across different methods or sources. RMSSD and SDNN require separate baselines.',
 ].join('\n');
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -79,6 +80,21 @@ function safeDate(value?: string): string | undefined {
   return value ? value.slice(0, 10) : undefined;
 }
 
+function hrvContext(day: DailyMetrics) {
+  if (day.hrvLastNightAvg == null) {
+    return null;
+  }
+
+  return {
+    valueMs: day.hrvLastNightAvg,
+    method: day.hrvMethod,
+    canonicalType: day.hrvCanonicalType,
+    sourceApp: day.hrvSourceApp,
+    sourceKey: day.hrvSourceKey,
+    sampleCount: day.hrvSampleCount,
+  };
+}
+
 function buildCoachContext(snapshot: PipelineSnapshot, healthContext: CoachHealthContext) {
   return {
     generatedAt: new Date().toISOString(),
@@ -111,7 +127,7 @@ function buildCoachContext(snapshot: PipelineSnapshot, healthContext: CoachHealt
           sleep: snapshot.today.sleepSeconds
             ? formatDuration(snapshot.today.sleepSeconds)
             : null,
-          hrvRmssd: snapshot.today.hrvLastNightAvg,
+          hrv: hrvContext(snapshot.today),
           restingHr: snapshot.today.restingHr,
           steps: snapshot.today.steps,
           activeKcal: snapshot.today.activeKcal,
@@ -123,7 +139,7 @@ function buildCoachContext(snapshot: PipelineSnapshot, healthContext: CoachHealt
       date: day.date,
       wellnessDataStatus: day.wellnessDataStatus,
       sleep: day.sleepSeconds ? formatDuration(day.sleepSeconds) : null,
-      hrvRmssd: day.hrvLastNightAvg,
+      hrv: hrvContext(day),
       restingHr: day.restingHr,
       steps: day.steps,
       workoutCount: day.workoutCount,
@@ -161,7 +177,7 @@ function buildCoachContext(snapshot: PipelineSnapshot, healthContext: CoachHealt
         wellnessDataStatus: day.wellnessDataStatus,
         sourceCount: day.sourceCount,
         sleep: day.sleepSeconds ? formatDuration(day.sleepSeconds) : null,
-        hrvRmssd: day.hrvLastNightAvg,
+        hrv: hrvContext(day),
         restingHr: day.restingHr,
         heartRateAvgBpm: day.heartRateAvgBpm,
         steps: day.steps,

--- a/src/health/appleHealth.ts
+++ b/src/health/appleHealth.ts
@@ -23,6 +23,7 @@ import type {
   CanonicalType,
   HealthConnectReadDiagnostic,
   HealthSample,
+  HrvMethod,
   NutritionDailyRecord,
   SleepSessionRecord,
   SportBucket,
@@ -42,6 +43,7 @@ type HealthKitReadConfig = {
 type HealthKitQuantityConfig = HealthKitReadConfig & {
   identifier: QuantityTypeIdentifier;
   unit: string;
+  hrvMethod?: HrvMethod;
   nutritionField?: NutritionNumberField;
   nutrientKey?: string;
   metadata?: Record<string, unknown>;
@@ -140,8 +142,10 @@ const quantityConfigs: HealthKitQuantityConfig[] = [
     canonicalType: 'hrv_sdnn',
     readKind: 'records',
     unit: 'ms',
+    hrvMethod: 'sdnn',
     metadata: {
-      hrvMethod: 'SDNN',
+      hrvMethod: 'sdnn',
+      hrvMethodLabel: 'SDNN',
       hrvMethodSource: 'Apple HealthKit heartRateVariabilitySDNN',
     },
   },
@@ -377,6 +381,7 @@ function quantitySample(
     localDate: localDateKey(record.startDate),
     value: numeric(record.quantity),
     unit: record.unit ?? config.unit,
+    hrvMethod: config.hrvMethod,
     metadataJson: metadataJson(record, {
       quantityIdentifier: config.identifier,
       ...config.metadata,

--- a/src/health/healthConnect.ts
+++ b/src/health/healthConnect.ts
@@ -23,6 +23,7 @@ import type {
   CanonicalType,
   HealthConnectReadDiagnostic,
   HealthSample,
+  HrvMethod,
   NutritionDailyRecord,
   SleepSessionRecord,
   SportBucket,
@@ -97,6 +98,28 @@ type RecordMetadata = {
     type?: number;
   };
 };
+
+function hrvMethodForCanonicalType(canonicalType: CanonicalType): HrvMethod | undefined {
+  if (canonicalType === 'hrv_rmssd') return 'rmssd';
+  if (canonicalType === 'hrv_sdnn') return 'sdnn';
+  return undefined;
+}
+
+function healthConnectMetadataJson(
+  record: unknown,
+  extra?: Record<string, unknown>,
+): string {
+  if (!extra) {
+    return safeJsonStringify(record);
+  }
+
+  return safeJsonStringify({
+    ...(typeof record === 'object' && record !== null && !Array.isArray(record)
+      ? record
+      : { raw: record }),
+    healthConnect: extra,
+  });
+}
 
 type TimedRecord = {
   metadata?: RecordMetadata;
@@ -191,6 +214,7 @@ function healthSample({
   const timed = record as TimedRecord;
   const resolvedStart = startAt ?? recordStart(timed);
   const resolvedEnd = endAt ?? recordEnd(timed);
+  const hrvMethod = hrvMethodForCanonicalType(canonicalType);
 
   return {
     sampleId: `health_connect:${recordType}:${metadata?.id ?? index}:${resolvedStart}`,
@@ -204,7 +228,17 @@ function healthSample({
     localDate: localDateKey(resolvedStart),
     value,
     unit,
-    metadataJson: safeJsonStringify(record),
+    hrvMethod,
+    metadataJson: healthConnectMetadataJson(
+      record,
+      hrvMethod
+        ? {
+            hrvMethod,
+            hrvMethodLabel: hrvMethod.toUpperCase(),
+            hrvMethodSource: `Health Connect ${recordType}Record`,
+          }
+        : undefined,
+    ),
     sourceModifiedAt: metadata?.lastModifiedTime,
   };
 }

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -22,6 +22,16 @@ export type CanonicalType =
 
 export type HealthMetric = CanonicalType;
 
+export type HrvCanonicalType = Extract<CanonicalType, 'hrv_rmssd' | 'hrv_sdnn'>;
+
+export type HrvMethod = 'rmssd' | 'sdnn';
+
+export type HrvBaselineStatus =
+  | 'compatible'
+  | 'missing_current'
+  | 'insufficient_baseline'
+  | 'method_incompatible';
+
 export type SportBucket = 'run' | 'ride' | 'strength' | 'swim' | 'walk' | 'other';
 
 export type SourceFreshnessState = 'fresh' | 'stale' | 'missing' | 'partial';
@@ -63,6 +73,7 @@ export type HealthSample = {
   timezone?: string;
   value?: number;
   unit?: string;
+  hrvMethod?: HrvMethod;
   metadataJson: string;
   sourceModifiedAt?: string;
 };
@@ -184,6 +195,11 @@ export type DailyMetrics = {
   heartRateMinBpm?: number;
   heartRateMaxBpm?: number;
   hrvLastNightAvg?: number;
+  hrvMethod?: HrvMethod;
+  hrvCanonicalType?: HrvCanonicalType;
+  hrvSourceApp?: string;
+  hrvSourceKey?: string;
+  hrvSampleCount?: number;
   workoutCount?: number;
   runWorkoutCount?: number;
   rideWorkoutCount?: number;

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -6,6 +6,9 @@ import { formatDuration, localDateKey } from '../lib/dates';
 import { safeJsonStringify } from '../lib/json';
 import {
   buildDailyMetricsRollup,
+  hrvBaselineFor,
+  hrvMethodForCanonicalType,
+  hrvMethodLabel,
   normalizeLegacyHealthSampleRow,
   type LegacyHealthSampleRow,
 } from './trainingStoreRules';
@@ -16,6 +19,8 @@ import type {
   HealthConnectReadDiagnostic,
   HealthProvider,
   HealthSample,
+  HrvCanonicalType,
+  HrvMethod,
   MetricAvailability,
   NutritionDailyRecord,
   PipelineSnapshot,
@@ -41,6 +46,7 @@ export type HealthSampleRow = {
   timezone: string | null;
   value: number | null;
   unit: string | null;
+  hrv_method: HrvMethod | null;
   metadata_json: string;
   source_modified_at: string | null;
   imported_at: string;
@@ -145,6 +151,7 @@ type LatestSampleByTypeRow = {
   start_at: string;
   value: number | null;
   unit: string | null;
+  hrv_method: HrvMethod | null;
 };
 
 type SourceValueRow = {
@@ -153,6 +160,26 @@ type SourceValueRow = {
   sample_count: number;
   latest_end_at: string | null;
   source_is_combined: number;
+};
+
+type HrvRollupRow = {
+  source_key: string;
+  source_app: string | null;
+  canonical_type: HrvCanonicalType;
+  hrv_method: HrvMethod;
+  value: number | null;
+  sample_count: number;
+  source_days: number | null;
+  latest_end_at: string | null;
+};
+
+type HrvMethodStatsRow = {
+  canonical_type: HrvCanonicalType;
+  hrv_method: HrvMethod | null;
+  source_key: string;
+  source_app: string | null;
+  sample_count: number;
+  day_count: number;
 };
 
 type SleepRollupRow = {
@@ -188,6 +215,11 @@ type DailyMetricsRow = {
   heart_rate_min_bpm: number | null;
   heart_rate_max_bpm: number | null;
   hrv_last_night_avg: number | null;
+  hrv_method: HrvMethod | null;
+  hrv_canonical_type: HrvCanonicalType | null;
+  hrv_source_app: string | null;
+  hrv_source_key: string | null;
+  hrv_sample_count: number | null;
   workout_count: number | null;
   run_workout_count: number | null;
   ride_workout_count: number | null;
@@ -236,6 +268,7 @@ export type CoachHealthContext = {
     startAt: string;
     value?: number;
     unit?: string;
+    hrvMethod?: HrvMethod;
   }[];
   recentDailyMetrics: DailyMetrics[];
   recentWorkouts: {
@@ -719,6 +752,68 @@ async function presentCanonicalTypesFor(
   return new Set(rows.filter((row) => Number(row.sample_count) > 0).map((row) => row.canonical_type));
 }
 
+async function hrvMethodStatsFor(db: SQLite.SQLiteDatabase): Promise<HrvMethodStatsRow[]> {
+  return db.getAllAsync<HrvMethodStatsRow>(`
+    WITH hrv_samples AS (
+      SELECT
+        canonical_type,
+        COALESCE(
+          hrv_method,
+          CASE canonical_type
+            WHEN 'hrv_rmssd' THEN 'rmssd'
+            WHEN 'hrv_sdnn' THEN 'sdnn'
+          END
+        ) AS hrv_method,
+        COALESCE(NULLIF(source_app, ''), NULLIF(source_device, ''), platform || ':' || record_type)
+          AS source_key,
+        source_app,
+        local_date,
+        value
+      FROM health_samples
+      WHERE canonical_type IN ('hrv_rmssd', 'hrv_sdnn')
+        AND value IS NOT NULL
+    )
+    SELECT
+      canonical_type,
+      hrv_method,
+      source_key,
+      MAX(source_app) AS source_app,
+      COUNT(*) AS sample_count,
+      COUNT(DISTINCT local_date) AS day_count
+    FROM hrv_samples
+    GROUP BY canonical_type, hrv_method, source_key
+    ORDER BY day_count DESC, sample_count DESC, source_key ASC
+  `);
+}
+
+function hrvMethodLimitations(stats: HrvMethodStatsRow[]): string[] {
+  if (!stats.length) {
+    return [];
+  }
+
+  const methods = Array.from(
+    new Set(
+      stats
+        .map((row) => row.hrv_method ?? hrvMethodForCanonicalType(row.canonical_type))
+        .filter((method): method is HrvMethod => Boolean(method)),
+    ),
+  );
+  const limitations: string[] = [];
+
+  if (methods.length > 1 || stats.length > 1) {
+    const methodList = methods.map(hrvMethodLabel).join(' and ');
+    limitations.push(
+      `Imported HRV has ${methodList}; readiness compares only matching source and method.`,
+    );
+  }
+
+  if (stats.some((row) => !row.hrv_method)) {
+    limitations.push('Some HRV rows were imported before method metadata was explicit.');
+  }
+
+  return limitations;
+}
+
 function buildFreshnessLimitations({
   config,
   diagnostics,
@@ -826,13 +921,21 @@ async function getSourceFreshness(db: SQLite.SQLiteDatabase): Promise<SourceFres
       today,
       latestDate,
     });
+    if (config.domain === 'hrv') {
+      limitations.push(...hrvMethodLimitations(await hrvMethodStatsFor(db)));
+    }
 
     let state: SourceFreshness['state'] = 'fresh';
     if (!sampleCount) {
       state = 'missing';
     } else if (ageDays != null && ageDays > config.maxFreshAgeDays) {
       state = 'stale';
-    } else if (missingTypes.length || (config.todayIsPartial && latestDate === today)) {
+    } else if (
+      missingTypes.length ||
+      (config.todayIsPartial && latestDate === today) ||
+      (config.domain === 'hrv' &&
+        limitations.some((limitation) => limitation.startsWith('Imported HRV has ')))
+    ) {
       state = 'partial';
     }
 
@@ -846,7 +949,7 @@ async function getSourceFreshness(db: SQLite.SQLiteDatabase): Promise<SourceFres
       latestLocalDate: latestDate,
       lastUpdatedAt: stats?.last_updated_at ?? undefined,
       ageDays,
-      limitations,
+      limitations: Array.from(new Set(limitations)),
     });
   }
 
@@ -877,6 +980,11 @@ function toDailyMetrics(row: DailyMetricsRow): DailyMetrics {
     heartRateMinBpm: optionalNumber(row.heart_rate_min_bpm),
     heartRateMaxBpm: optionalNumber(row.heart_rate_max_bpm),
     hrvLastNightAvg: optionalNumber(row.hrv_last_night_avg),
+    hrvMethod: row.hrv_method ?? undefined,
+    hrvCanonicalType: row.hrv_canonical_type ?? undefined,
+    hrvSourceApp: row.hrv_source_app ?? undefined,
+    hrvSourceKey: row.hrv_source_key ?? undefined,
+    hrvSampleCount: optionalNumber(row.hrv_sample_count),
     workoutCount: optionalNumber(row.workout_count),
     runWorkoutCount: optionalNumber(row.run_workout_count),
     rideWorkoutCount: optionalNumber(row.ride_workout_count),
@@ -922,6 +1030,40 @@ async function migrateLegacyHealthSamples(db: SQLite.SQLiteDatabase): Promise<vo
   `);
 }
 
+async function ensureColumn(
+  db: SQLite.SQLiteDatabase,
+  table: string,
+  column: string,
+  definition: string,
+): Promise<void> {
+  const columns = await db.getAllAsync<{ name: string }>(`PRAGMA table_info(${table})`);
+  if (columns.some((item) => item.name === column)) {
+    return;
+  }
+
+  await db.execAsync(`ALTER TABLE ${table} ADD COLUMN ${definition};`);
+}
+
+async function ensureHrvSchema(db: SQLite.SQLiteDatabase): Promise<void> {
+  await ensureColumn(db, 'health_samples', 'hrv_method', 'hrv_method TEXT');
+  await ensureColumn(db, 'daily_metrics', 'hrv_method', 'hrv_method TEXT');
+  await ensureColumn(db, 'daily_metrics', 'hrv_canonical_type', 'hrv_canonical_type TEXT');
+  await ensureColumn(db, 'daily_metrics', 'hrv_source_app', 'hrv_source_app TEXT');
+  await ensureColumn(db, 'daily_metrics', 'hrv_source_key', 'hrv_source_key TEXT');
+  await ensureColumn(db, 'daily_metrics', 'hrv_sample_count', 'hrv_sample_count INTEGER');
+
+  await db.execAsync(`
+    UPDATE health_samples
+    SET hrv_method = CASE canonical_type
+      WHEN 'hrv_rmssd' THEN 'rmssd'
+      WHEN 'hrv_sdnn' THEN 'sdnn'
+      ELSE hrv_method
+    END
+    WHERE hrv_method IS NULL
+      AND canonical_type IN ('hrv_rmssd', 'hrv_sdnn');
+  `);
+}
+
 async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
   await db.execAsync(`
     CREATE TABLE IF NOT EXISTS health_samples (
@@ -937,6 +1079,7 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
       timezone TEXT,
       value REAL,
       unit TEXT,
+      hrv_method TEXT,
       metadata_json TEXT NOT NULL,
       source_modified_at TEXT,
       imported_at TEXT NOT NULL
@@ -947,6 +1090,9 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_health_samples_platform_time
       ON health_samples(platform, start_at);
+
+    CREATE INDEX IF NOT EXISTS idx_health_samples_hrv_method
+      ON health_samples(hrv_method, canonical_type, local_date);
 
     CREATE TABLE IF NOT EXISTS sleep_sessions (
       sleep_id TEXT PRIMARY KEY NOT NULL,
@@ -1040,6 +1186,11 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
       heart_rate_min_bpm REAL,
       heart_rate_max_bpm REAL,
       hrv_last_night_avg REAL,
+      hrv_method TEXT,
+      hrv_canonical_type TEXT,
+      hrv_source_app TEXT,
+      hrv_source_key TEXT,
+      hrv_sample_count INTEGER,
       workout_count INTEGER,
       run_workout_count INTEGER,
       ride_workout_count INTEGER,
@@ -1088,6 +1239,8 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
       ON health_connect_diagnostics(sync_started_at);
   `);
 
+  await ensureHrvSchema(db);
+
   const legacyColumns = await db.getAllAsync<{ name: string }>(
     'PRAGMA table_info(health_samples_legacy)',
   );
@@ -1105,9 +1258,9 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
         `
           INSERT OR IGNORE INTO health_samples (
             sample_id, platform, record_type, canonical_type, source_app, source_device,
-            start_at, end_at, local_date, value, unit, metadata_json, imported_at
+            start_at, end_at, local_date, value, unit, hrv_method, metadata_json, imported_at
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
         sample.sampleId,
         sample.platform,
@@ -1120,6 +1273,7 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
         sample.localDate,
         sample.value,
         sample.unit,
+        sample.hrvMethod,
         sample.metadataJson,
         sample.importedAt,
       );
@@ -1197,10 +1351,10 @@ export async function upsertSyncPayload(payload: SyncPayload): Promise<number> {
         `
           INSERT OR REPLACE INTO health_samples (
             sample_id, platform, record_type, canonical_type, source_app, source_device,
-            start_at, end_at, local_date, timezone, value, unit, metadata_json,
+            start_at, end_at, local_date, timezone, value, unit, hrv_method, metadata_json,
             source_modified_at, imported_at
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
         sample.sampleId,
         sample.platform,
@@ -1214,6 +1368,7 @@ export async function upsertSyncPayload(payload: SyncPayload): Promise<number> {
         sample.timezone ?? null,
         sample.value ?? null,
         sample.unit ?? null,
+        sample.hrvMethod ?? hrvMethodForCanonicalType(sample.canonicalType) ?? null,
         sample.metadataJson,
         sample.sourceModifiedAt ?? null,
         importedAt,
@@ -1515,6 +1670,83 @@ async function latestValueFor(
   return optionalNumber(row?.value);
 }
 
+async function selectedHrvFor(
+  db: SQLite.SQLiteDatabase,
+  date: string,
+): Promise<HrvRollupRow | null> {
+  return db.getFirstAsync<HrvRollupRow>(
+    `
+      WITH hrv_samples AS (
+        SELECT
+          local_date,
+          canonical_type,
+          COALESCE(
+            hrv_method,
+            CASE canonical_type
+              WHEN 'hrv_rmssd' THEN 'rmssd'
+              WHEN 'hrv_sdnn' THEN 'sdnn'
+            END
+          ) AS hrv_method,
+          COALESCE(NULLIF(source_app, ''), NULLIF(source_device, ''), platform || ':' || record_type)
+            AS source_key,
+          source_app,
+          value,
+          end_at
+        FROM health_samples
+        WHERE canonical_type IN ('hrv_rmssd', 'hrv_sdnn')
+          AND value IS NOT NULL
+      ),
+      source_rank AS (
+        SELECT
+          source_key,
+          canonical_type,
+          hrv_method,
+          COUNT(DISTINCT local_date) AS source_days
+        FROM hrv_samples
+        WHERE hrv_method IS NOT NULL
+        GROUP BY source_key, canonical_type, hrv_method
+      ),
+      day_source AS (
+        SELECT
+          source_key,
+          MAX(source_app) AS source_app,
+          canonical_type,
+          hrv_method,
+          AVG(value) AS value,
+          COUNT(*) AS sample_count,
+          MAX(end_at) AS latest_end_at
+        FROM hrv_samples
+        WHERE local_date = ?
+          AND hrv_method IS NOT NULL
+        GROUP BY source_key, canonical_type, hrv_method
+        HAVING AVG(value) IS NOT NULL
+      )
+      SELECT
+        day_source.source_key,
+        day_source.source_app,
+        day_source.canonical_type,
+        day_source.hrv_method,
+        day_source.value,
+        day_source.sample_count,
+        source_rank.source_days,
+        day_source.latest_end_at
+      FROM day_source
+      LEFT JOIN source_rank
+        ON source_rank.source_key = day_source.source_key
+        AND source_rank.canonical_type = day_source.canonical_type
+        AND source_rank.hrv_method = day_source.hrv_method
+      ORDER BY
+        source_rank.source_days DESC,
+        day_source.sample_count DESC,
+        day_source.latest_end_at DESC,
+        CASE day_source.canonical_type WHEN 'hrv_rmssd' THEN 0 ELSE 1 END ASC,
+        day_source.source_key ASC
+      LIMIT 1
+    `,
+    date,
+  );
+}
+
 async function rebuildDailyMetrics(): Promise<void> {
   const db = await getDb();
   const dates = await distinctMetricDates(db);
@@ -1532,7 +1764,7 @@ async function rebuildDailyMetrics(): Promise<void> {
     const heartRateMin = await valueFor(db, date, 'heart_rate', 'MIN');
     const heartRateMax = await valueFor(db, date, 'heart_rate', 'MAX');
     const restingHr = await valueFor(db, date, 'resting_heart_rate', 'AVG');
-    const hrv = await valueFor(db, date, 'hrv_rmssd', 'AVG');
+    const hrv = await selectedHrvFor(db, date);
     const sleepFallback = await singleSourceSumFor(db, date, 'sleep_session');
     const weightKg = await latestValueFor(db, date, 'weight');
     const bodyFatPct = await latestValueFor(db, date, 'body_fat');
@@ -1588,7 +1820,12 @@ async function rebuildDailyMetrics(): Promise<void> {
       heartRateAvgBpm: heartRateAvg,
       heartRateMinBpm: heartRateMin,
       heartRateMaxBpm: heartRateMax,
-      hrvLastNightAvg: hrv,
+      hrvLastNightAvg: optionalNumber(hrv?.value),
+      hrvMethod: hrv?.hrv_method ?? undefined,
+      hrvCanonicalType: hrv?.canonical_type ?? undefined,
+      hrvSourceApp: hrv?.source_app ?? undefined,
+      hrvSourceKey: hrv?.source_key ?? undefined,
+      hrvSampleCount: optionalNumber(hrv?.sample_count),
       workout: {
         workoutCount: workout.workout_count,
         runWorkoutCount: workout.run_workout_count,
@@ -1622,13 +1859,14 @@ async function rebuildDailyMetrics(): Promise<void> {
           has_steps, has_energy, steps, active_kcal, total_kcal, distance_km,
           sleep_seconds, time_in_bed_seconds, sleep_efficiency, resting_hr,
           heart_rate_avg_bpm, heart_rate_min_bpm, heart_rate_max_bpm,
-          hrv_last_night_avg, workout_count, run_workout_count,
+          hrv_last_night_avg, hrv_method, hrv_canonical_type, hrv_source_app,
+          hrv_source_key, hrv_sample_count, workout_count, run_workout_count,
           ride_workout_count, strength_workout_count, activity_elapsed_seconds,
           activity_kcal, kcal_in, protein_g, carbs_g, fat_g, fiber_g, sugar_g,
           water_ml, weight_kg, body_fat_pct, lean_body_mass_kg, vo2max,
           generated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       daily.date,
       daily.dataCompleteness,
@@ -1652,6 +1890,11 @@ async function rebuildDailyMetrics(): Promise<void> {
       daily.heartRateMinBpm ?? null,
       daily.heartRateMaxBpm ?? null,
       daily.hrvLastNightAvg ?? null,
+      daily.hrvMethod ?? null,
+      daily.hrvCanonicalType ?? null,
+      daily.hrvSourceApp ?? null,
+      daily.hrvSourceKey ?? null,
+      daily.hrvSampleCount ?? null,
       daily.workoutCount ?? null,
       daily.runWorkoutCount ?? null,
       daily.rideWorkoutCount ?? null,
@@ -1734,13 +1977,10 @@ function deriveRecommendation(
 
   const baselineRows = history.filter((row) => row.date !== current.date).slice(0, 14);
   const sleepHours = (current.sleepSeconds ?? 0) / 3600;
-  const hrvBaseline = average(baselineRows.map((row) => row.hrvLastNightAvg));
+  const hrvBaseline = hrvBaselineFor(current, history);
   const rhrBaseline = average(baselineRows.map((row) => row.restingHr));
   const sleepBaseline = average(baselineRows.map((row) => row.sleepSeconds));
-  const hrvDelta =
-    current.hrvLastNightAvg != null && hrvBaseline
-      ? current.hrvLastNightAvg - hrvBaseline
-      : undefined;
+  const hrvDelta = hrvBaseline.delta;
   const rhrDelta =
     current.restingHr != null && rhrBaseline ? current.restingHr - rhrBaseline : undefined;
   const sleepDelta =
@@ -1766,11 +2006,17 @@ function deriveRecommendation(
   if (hrvDelta != null) {
     if (hrvDelta > 8) {
       readiness += 16;
-      signals.push(`HRV is up ${Math.round(hrvDelta)} ms`);
+      signals.push(`${hrvMethodLabel(current.hrvMethod)} HRV is up ${Math.round(hrvDelta)} ms`);
     } else if (hrvDelta < -8) {
       readiness -= 22;
-      signals.push(`HRV is down ${Math.abs(Math.round(hrvDelta))} ms`);
+      signals.push(`${hrvMethodLabel(current.hrvMethod)} HRV is down ${Math.abs(Math.round(hrvDelta))} ms`);
     }
+  } else if (current.hrvLastNightAvg != null && hrvBaseline.status === 'method_incompatible') {
+    signals.push(
+      `${hrvMethodLabel(current.hrvMethod)} HRV is available, but incompatible HRV history was ignored`,
+    );
+  } else if (current.hrvLastNightAvg != null && hrvBaseline.status === 'insufficient_baseline') {
+    signals.push(`${hrvMethodLabel(current.hrvMethod)} HRV needs more matching history`);
   }
 
   if (rhrDelta != null) {
@@ -1953,6 +2199,7 @@ export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {
       timezone: row.timezone ?? undefined,
       value: row.value ?? undefined,
       unit: row.unit ?? undefined,
+      hrvMethod: row.hrv_method ?? undefined,
       metadataJson: row.metadata_json,
       sourceModifiedAt: row.source_modified_at ?? undefined,
     })),
@@ -2024,7 +2271,7 @@ export async function getCoachHealthContext({
       GROUP BY canonical_type
     `),
     db.getAllAsync<LatestSampleByTypeRow>(`
-      SELECT canonical_type, record_type, source_app, local_date, start_at, value, unit
+      SELECT canonical_type, record_type, source_app, local_date, start_at, value, unit, hrv_method
       FROM (
         SELECT
           canonical_type,
@@ -2034,6 +2281,7 @@ export async function getCoachHealthContext({
           start_at,
           value,
           unit,
+          hrv_method,
           ROW_NUMBER() OVER (
             PARTITION BY canonical_type
             ORDER BY start_at DESC, imported_at DESC
@@ -2102,6 +2350,7 @@ export async function getCoachHealthContext({
       startAt: sample.start_at,
       value: sample.value ?? undefined,
       unit: sample.unit ?? undefined,
+      hrvMethod: sample.hrv_method ?? undefined,
     })),
     recentDailyMetrics: dailyRows.map(toDailyMetrics),
     recentWorkouts: recentWorkouts.map((workout) => ({
@@ -2184,7 +2433,7 @@ export async function exportPipelineJson(): Promise<string> {
     ]);
 
   const payload = {
-    schema: 'biostream_training_pipeline.v3',
+    schema: 'biostream_training_pipeline.v4',
     exportedAt: new Date().toISOString(),
     samples,
     sleepSessions,

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -23,6 +23,7 @@ export type HealthSampleRow = {
   timezone: string | null;
   value: number | null;
   unit: string | null;
+  hrv_method: 'rmssd' | 'sdnn' | null;
   metadata_json: string;
   source_modified_at: string | null;
   imported_at: string;
@@ -94,6 +95,11 @@ function day(offset = 0): DailyMetrics {
     heartRateMinBpm: 45,
     heartRateMaxBpm: 161,
     hrvLastNightAvg: offset === 0 ? 62 : 56 + Math.abs(offset),
+    hrvMethod: 'rmssd',
+    hrvCanonicalType: 'hrv_rmssd',
+    hrvSourceApp: 'Apple Watch',
+    hrvSourceKey: 'Apple Watch',
+    hrvSampleCount: 1,
     workoutCount: offset === -1 || offset === -3 ? 1 : 0,
     runWorkoutCount: offset === -1 ? 1 : 0,
     rideWorkoutCount: 0,
@@ -179,7 +185,7 @@ const demoSourceFreshness: SourceFreshness[] = [
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T06:45:00.000Z`,
     ageDays: 0,
-    limitations: [],
+    limitations: ['Demo HRV is RMSSD; SDNN from Apple Health would use its own baseline.'],
   },
   {
     domain: 'workouts',
@@ -328,7 +334,7 @@ const demoSnapshot: PipelineSnapshot = {
     color: 'positive',
     title: 'Aerobic base',
     detail: '40 min easy run, stay conversational',
-    reason: 'Sleep is solid, HRV is above baseline, and recent training load is consistent.',
+    reason: 'Sleep is solid, RMSSD HRV is above its matching baseline, and recent training load is consistent.',
     opener: 'Morning. Your wearable data already shows a strong recovery profile today.',
     strain: 9.5,
     strainTarget: '8-11',
@@ -432,6 +438,7 @@ export async function getCoachHealthContext(_options: { rebuildDaily?: boolean }
         startAt: `${latestDate}T06:45:00.000Z`,
         value: history[0].hrvLastNightAvg,
         unit: 'ms',
+        hrvMethod: 'rmssd' as const,
       },
       {
         canonicalType: 'resting_heart_rate' as CanonicalType,

--- a/src/storage/trainingStoreRules.test.cjs
+++ b/src/storage/trainingStoreRules.test.cjs
@@ -5,6 +5,7 @@ const path = require('node:path');
 const fixtures = require('./fixtures/training-rollup.fixtures.json');
 const {
   buildDailyMetricsRollup,
+  hrvBaselineFor,
   normalizeLegacyHealthSampleRow,
 } = require(path.join(process.cwd(), '.tmp/test-build/src/storage/trainingStoreRules.js'));
 
@@ -72,6 +73,8 @@ function sleepForWakeDate(date) {
 }
 
 function rollupFor(date, overrides = {}) {
+  const hrv = averageFor(date, 'hrv_rmssd');
+
   return buildDailyMetricsRollup({
     date,
     today: fixtures.today,
@@ -85,7 +88,12 @@ function rollupFor(date, overrides = {}) {
     heartRateAvgBpm: averageFor(date, 'heart_rate'),
     heartRateMinBpm: minFor(date, 'heart_rate'),
     heartRateMaxBpm: maxFor(date, 'heart_rate'),
-    hrvLastNightAvg: averageFor(date, 'hrv_rmssd'),
+    hrvLastNightAvg: hrv,
+    hrvMethod: hrv == null ? undefined : 'rmssd',
+    hrvCanonicalType: hrv == null ? undefined : 'hrv_rmssd',
+    hrvSourceApp: hrv == null ? undefined : 'Health Connect',
+    hrvSourceKey: hrv == null ? undefined : 'Health Connect',
+    hrvSampleCount: hrv == null ? undefined : 1,
     workout: workoutRollupFor(date),
     nutrition: nutritionFor(date),
     weightKg: latestFor(date, 'weight'),
@@ -102,11 +110,76 @@ test('rolls up a full fixture day without assigning sleep to its start date', ()
   assert.equal(wakeDay.hasSleep, true);
   assert.equal(wakeDay.sleepSeconds, 25200);
   assert.equal(wakeDay.distanceKm, 6.4);
+  assert.equal(wakeDay.hrvMethod, 'rmssd');
+  assert.equal(wakeDay.hrvCanonicalType, 'hrv_rmssd');
   assert.equal(wakeDay.workoutCount, 1);
   assert.equal(wakeDay.kcalIn, 2210);
 
   assert.equal(sleepStartDay.hasSleep, false);
   assert.equal(sleepStartDay.sleepSeconds, undefined);
+});
+
+test('separates HRV baselines by method and source', () => {
+  const current = {
+    date: '2026-04-29',
+    hrvLastNightAvg: 42,
+    hrvMethod: 'sdnn',
+    hrvCanonicalType: 'hrv_sdnn',
+    hrvSourceKey: 'apple-watch',
+  };
+  const incompatible = hrvBaselineFor(current, [
+    current,
+    {
+      date: '2026-04-28',
+      hrvLastNightAvg: 68,
+      hrvMethod: 'rmssd',
+      hrvCanonicalType: 'hrv_rmssd',
+      hrvSourceKey: 'health-connect',
+    },
+    {
+      date: '2026-04-27',
+      hrvLastNightAvg: 65,
+      hrvMethod: 'rmssd',
+      hrvCanonicalType: 'hrv_rmssd',
+      hrvSourceKey: 'health-connect',
+    },
+  ]);
+
+  assert.equal(incompatible.status, 'method_incompatible');
+  assert.equal(incompatible.baseline, undefined);
+  assert.equal(incompatible.compatibleDays, 0);
+  assert.equal(incompatible.incompatibleDays, 2);
+
+  const compatible = hrvBaselineFor(current, [
+    current,
+    {
+      date: '2026-04-28',
+      hrvLastNightAvg: 40,
+      hrvMethod: 'sdnn',
+      hrvCanonicalType: 'hrv_sdnn',
+      hrvSourceKey: 'apple-watch',
+    },
+    {
+      date: '2026-04-27',
+      hrvLastNightAvg: 44,
+      hrvMethod: 'sdnn',
+      hrvCanonicalType: 'hrv_sdnn',
+      hrvSourceKey: 'apple-watch',
+    },
+    {
+      date: '2026-04-26',
+      hrvLastNightAvg: 70,
+      hrvMethod: 'rmssd',
+      hrvCanonicalType: 'hrv_rmssd',
+      hrvSourceKey: 'health-connect',
+    },
+  ]);
+
+  assert.equal(compatible.status, 'compatible');
+  assert.equal(compatible.baseline, 42);
+  assert.equal(compatible.delta, 0);
+  assert.equal(compatible.compatibleDays, 2);
+  assert.equal(compatible.incompatibleDays, 1);
 });
 
 test('keeps partial days partial and does not coerce missing values to zero', () => {

--- a/src/storage/trainingStoreRules.ts
+++ b/src/storage/trainingStoreRules.ts
@@ -1,5 +1,12 @@
 import { localDateKey } from '../lib/dates';
-import type { CanonicalType, DailyMetrics, HealthProvider } from '../health/types';
+import type {
+  CanonicalType,
+  DailyMetrics,
+  HealthProvider,
+  HrvBaselineStatus,
+  HrvCanonicalType,
+  HrvMethod,
+} from '../health/types';
 
 export type DailyWorkoutRollup = {
   workoutCount: number;
@@ -42,6 +49,11 @@ export type DailyMetricsRollupInput = {
   heartRateMinBpm?: number;
   heartRateMaxBpm?: number;
   hrvLastNightAvg?: number;
+  hrvMethod?: HrvMethod;
+  hrvCanonicalType?: HrvCanonicalType;
+  hrvSourceApp?: string;
+  hrvSourceKey?: string;
+  hrvSampleCount?: number;
   workout: DailyWorkoutRollup;
   nutrition?: DailyNutritionRollup | null;
   weightKg?: number;
@@ -76,8 +88,14 @@ export type NormalizedLegacyHealthSample = {
   localDate: string;
   value: number | null;
   unit: string | null;
+  hrvMethod: HrvMethod | null;
   metadataJson: string;
   importedAt: string;
+};
+
+const hrvMethodByCanonicalType: Partial<Record<CanonicalType, HrvMethod>> = {
+  hrv_rmssd: 'rmssd',
+  hrv_sdnn: 'sdnn',
 };
 
 function optionalNumber(value: number | null | undefined): number | undefined {
@@ -86,6 +104,110 @@ function optionalNumber(value: number | null | undefined): number | undefined {
 
 function hasValue(value: number | null | undefined): boolean {
   return value != null;
+}
+
+function average(values: number[]): number | undefined {
+  if (!values.length) {
+    return undefined;
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function hrvMethodForCanonicalType(type: CanonicalType): HrvMethod | undefined {
+  return hrvMethodByCanonicalType[type];
+}
+
+export function hrvMethodLabel(method?: HrvMethod): string {
+  if (method === 'rmssd') return 'RMSSD';
+  if (method === 'sdnn') return 'SDNN';
+  return 'HRV';
+}
+
+type HrvComparableDay = Pick<
+  DailyMetrics,
+  'date' | 'hrvLastNightAvg' | 'hrvMethod' | 'hrvCanonicalType' | 'hrvSourceKey'
+>;
+
+export type HrvBaselineResult = {
+  status: HrvBaselineStatus;
+  baseline?: number;
+  delta?: number;
+  compatibleDays: number;
+  incompatibleDays: number;
+  method?: HrvMethod;
+  canonicalType?: HrvCanonicalType;
+  sourceKey?: string;
+};
+
+function hasCompatibleHrvKey(current: HrvComparableDay, candidate: HrvComparableDay): boolean {
+  if (candidate.hrvLastNightAvg == null) {
+    return false;
+  }
+
+  if (
+    !current.hrvMethod ||
+    !candidate.hrvMethod ||
+    current.hrvMethod !== candidate.hrvMethod
+  ) {
+    return false;
+  }
+
+  if (
+    current.hrvCanonicalType &&
+    candidate.hrvCanonicalType &&
+    current.hrvCanonicalType !== candidate.hrvCanonicalType
+  ) {
+    return false;
+  }
+
+  if (current.hrvSourceKey || candidate.hrvSourceKey) {
+    return current.hrvSourceKey === candidate.hrvSourceKey;
+  }
+
+  return true;
+}
+
+export function hrvBaselineFor(
+  current: HrvComparableDay | null | undefined,
+  history: HrvComparableDay[],
+  maxDays = 14,
+): HrvBaselineResult {
+  if (current?.hrvLastNightAvg == null || !current.hrvMethod) {
+    return {
+      status: 'missing_current',
+      compatibleDays: 0,
+      incompatibleDays: 0,
+    };
+  }
+
+  const baselineRows = history.filter((row) => row.date !== current.date).slice(0, maxDays);
+  const hrvRows = baselineRows.filter((row) => row.hrvLastNightAvg != null);
+  const compatibleRows = hrvRows.filter((row) => hasCompatibleHrvKey(current, row));
+  const incompatibleDays = hrvRows.length - compatibleRows.length;
+  const baseline = average(compatibleRows.map((row) => row.hrvLastNightAvg as number));
+
+  if (baseline == null) {
+    return {
+      status: incompatibleDays ? 'method_incompatible' : 'insufficient_baseline',
+      compatibleDays: 0,
+      incompatibleDays,
+      method: current.hrvMethod,
+      canonicalType: current.hrvCanonicalType,
+      sourceKey: current.hrvSourceKey,
+    };
+  }
+
+  return {
+    status: 'compatible',
+    baseline,
+    delta: current.hrvLastNightAvg - baseline,
+    compatibleDays: compatibleRows.length,
+    incompatibleDays,
+    method: current.hrvMethod,
+    canonicalType: current.hrvCanonicalType,
+    sourceKey: current.hrvSourceKey,
+  };
 }
 
 export function buildDailyMetricsRollup(input: DailyMetricsRollupInput): DailyMetrics {
@@ -146,6 +268,11 @@ export function buildDailyMetricsRollup(input: DailyMetricsRollupInput): DailyMe
     heartRateMinBpm: optionalNumber(input.heartRateMinBpm),
     heartRateMaxBpm: optionalNumber(input.heartRateMaxBpm),
     hrvLastNightAvg: optionalNumber(input.hrvLastNightAvg),
+    hrvMethod: input.hrvMethod,
+    hrvCanonicalType: input.hrvCanonicalType,
+    hrvSourceApp: input.hrvSourceApp,
+    hrvSourceKey: input.hrvSourceKey,
+    hrvSampleCount: optionalNumber(input.hrvSampleCount),
     workoutCount: input.workout.workoutCount,
     runWorkoutCount: input.workout.runWorkoutCount,
     rideWorkoutCount: input.workout.rideWorkoutCount,
@@ -182,6 +309,7 @@ export function normalizeLegacyHealthSampleRow(
     localDate: localDateKey(row.start_time),
     value: row.value,
     unit: row.unit,
+    hrvMethod: hrvMethodForCanonicalType(row.metric as CanonicalType) ?? null,
     metadataJson: row.raw_json,
     importedAt: row.synced_at,
   };


### PR DESCRIPTION
## Summary
- Store explicit HRV method metadata for HealthKit SDNN and Health Connect RMSSD samples.
- Persist method/source details into daily HRV rollups and keep readiness baselines source- and method-compatible.
- Expose method-aware HRV context to the coach, source freshness, export schema, web demo data, and the HRV trend UI.
- Add rollup test coverage proving SDNN and RMSSD histories are not mixed.

Closes #10

## Verification
- npm run typecheck
- npm run test:rollups
- git diff --check origin/main..HEAD

## Notes
- Native iOS/Android device verification was not run in this environment.