### PR TITLE
[codex] Fix HRV index migration

### DIFF
--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -1122,6 +1122,9 @@ async function ensureHrvSchema(db: SQLite.SQLiteDatabase): Promise<void> {
     END
     WHERE hrv_method IS NULL
       AND canonical_type IN ('hrv_rmssd', 'hrv_sdnn');
+
+    CREATE INDEX IF NOT EXISTS idx_health_samples_hrv_method
+      ON health_samples(hrv_method, canonical_type, local_date);
   `);
 }
 
@@ -1151,9 +1154,6 @@ async function createSchema(db: SQLite.SQLiteDatabase): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_health_samples_platform_time
       ON health_samples(platform, start_at);
-
-    CREATE INDEX IF NOT EXISTS idx_health_samples_hrv_method
-      ON health_samples(hrv_method, canonical_type, local_date);
 
     CREATE TABLE IF NOT EXISTS sleep_sessions (
       sleep_id TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
## Summary
- Move the HRV method index creation out of the initial schema block.
- Create the index only after `ensureHrvSchema()` has added/backfilled `health_samples.hrv_method`.

## Why
Existing SQLite databases from before the HRV method migration do not have `hrv_method` yet. Creating an index on that column before the migration can fail app startup with `no such column: hrv_method`.

Follow-up to #47.

## Verification
- npm run typecheck
- npm run test:rollups
- git diff --check
