### PR TITLE
Track B structured coach output boundary

### DIFF
--- a/docs/feature-issues.md
+++ b/docs/feature-issues.md
@@ -182,6 +182,7 @@ or severe fatigue force safer guidance.
 **Scope:**
 
 - Create a risk flag model and helper functions.
+- Extend the `risk_flags` schema introduced by issue 25 with the actual flag catalog and extraction helpers.
 - Collect risk flags from onboarding, daily check-ins, and typed adjustments.
 - Add a conservative override layer before recommendations are shown.
 - Surface professional-care guidance for serious symptoms without diagnosing.

--- a/docs/plans/2026-04-29-openai-structured-output-boundary-design.md
+++ b/docs/plans/2026-04-29-openai-structured-output-boundary-design.md
@@ -1,0 +1,43 @@
+# OpenAI Structured Output Boundary Design
+
+Last updated: 2026-04-29
+
+## Objective
+
+Land Track B issue 25 by defining stable, local TypeScript contracts for coach structured output without requiring a live OpenAI API key. This branch also publishes the `risk_flags` schema shape so issue 6 can add risk detection and conservative overrides against a known contract.
+
+## Scope
+
+- Add TypeScript schema types for `goal_profile`, `event_profile`, `risk_flags`, `stale_data_report`, `readiness_status`, `daily_recommendation`, and `health_check`.
+- Add runtime validation helpers that reject missing required safety fields.
+- Add a coach service interface that can be backed by deterministic local logic now and model calls later.
+- Add mocked structured outputs for local development and tests.
+- Update issue 6 so its owner extends the `risk_flags` contract with extraction helpers and recommendation override behavior.
+
+## Out Of Scope
+
+- Production OpenAI API integration.
+- Prompt tuning.
+- Risk flag extraction from onboarding, check-ins, or typed adjustments.
+- Recommendation UI rewrites.
+
+## Architecture
+
+The contract lives in `src/coach/schemas.ts`. It exports discriminated string unions, structured output types, lightweight runtime validators, and `parse*` helpers that return typed values or throw a useful validation error.
+
+The service boundary lives in `src/coach/structuredCoach.ts`. It exposes a `StructuredCoachService` interface and a deterministic mock implementation. The app can use this interface in fixture-driven development while a later OpenAI-backed service maps the same contract to Structured Outputs.
+
+Mock outputs live in `src/coach/fixtures/structuredCoach.fixtures.ts` so tests and UI work can import complete examples without requiring credentials.
+
+## Risk Flags
+
+`risk_flags` is a required field in the structured response contract. This branch defines the stable shape: severity, category, source, evidence, recommendation impact, and professional-care guidance. Issue 6 remains responsible for detecting flags, merging flags from user/profile/check-in inputs, and applying conservative overrides before recommendations render.
+
+## Testing
+
+Add Jest tests covering:
+
+- A complete mocked structured response validates successfully.
+- Missing required `risk_flags` safety data fails validation.
+- The mock coach service returns the same structured contract without an API key.
+- Unknown or incomplete data can still produce conservative typed output.

--- a/docs/plans/2026-04-29-openai-structured-output-boundary.md
+++ b/docs/plans/2026-04-29-openai-structured-output-boundary.md
@@ -1,0 +1,118 @@
+# OpenAI Structured Output Boundary Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add local structured coach output schemas, validators, fixtures, and a mock service boundary for Track B without requiring live OpenAI API calls.
+
+**Architecture:** Keep the schema and validator layer headless under `src/coach`. Add a deterministic service interface beside the existing coach modules, and leave the current chat API wrapper untouched. Use Jest tests to lock the contract and make risk safety fields required.
+
+**Tech Stack:** TypeScript, Jest, Expo React Native app, existing `src/coach` modules.
+
+---
+
+### Task 1: Document Issue 6 Ownership
+
+**Files:**
+- Modify: `docs/feature-issues.md`
+
+**Step 1: Update issue 6 scope**
+
+Add a note that issue 25 owns the `risk_flags` schema shape, while issue 6 owns detection helpers, source collection, and conservative override behavior.
+
+**Step 2: Verify docs diff**
+
+Run: `git diff -- docs/feature-issues.md`
+
+Expected: Issue 6 clearly tells the owner to add the actual flags and override logic against the schema from issue 25.
+
+### Task 2: Write Contract Tests
+
+**Files:**
+- Create: `src/coach/structuredCoach.test.ts`
+
+**Step 1: Write failing tests**
+
+Cover:
+
+- `parseStructuredCoachOutput` accepts a complete fixture.
+- Missing `risk_flags` fails validation.
+- Missing required `risk_flags.items[].severity` fails validation.
+- `createMockStructuredCoachService` returns a valid structured output without an API key.
+
+**Step 2: Run tests to verify RED**
+
+Run: `npm test -- --runInBand src/coach/structuredCoach.test.ts`
+
+Expected: FAIL because schema/service modules do not exist yet.
+
+### Task 3: Implement Schema And Validators
+
+**Files:**
+- Create: `src/coach/schemas.ts`
+
+**Step 1: Add TypeScript contract**
+
+Define `GoalProfile`, `EventProfile`, `RiskFlags`, `StaleDataReport`, `ReadinessStatus`, `DailyRecommendation`, `HealthCheck`, and `StructuredCoachOutput`.
+
+**Step 2: Add validation helpers**
+
+Implement `parseStructuredCoachOutput(value: unknown): StructuredCoachOutput` and focused nested validators. Use plain TypeScript checks, no new dependency.
+
+**Step 3: Run tests**
+
+Run: `npm test -- --runInBand src/coach/structuredCoach.test.ts`
+
+Expected: Initial schema tests pass or fail only because the mock service is not implemented.
+
+### Task 4: Add Fixtures And Mock Service
+
+**Files:**
+- Create: `src/coach/fixtures/structuredCoach.fixtures.ts`
+- Create: `src/coach/structuredCoach.ts`
+
+**Step 1: Add complete fixtures**
+
+Export at least one complete conservative fixture and one helper for no-data/unknown-readiness output.
+
+**Step 2: Add service interface**
+
+Define `StructuredCoachService`, `StructuredCoachRequest`, and `createMockStructuredCoachService`.
+
+**Step 3: Validate service output**
+
+The mock service should call `parseStructuredCoachOutput` before returning.
+
+**Step 4: Run targeted tests**
+
+Run: `npm test -- --runInBand src/coach/structuredCoach.test.ts`
+
+Expected: PASS.
+
+### Task 5: Final Verification
+
+**Files:**
+- All touched files
+
+**Step 1: Run full tests**
+
+Run: `npm test -- --runInBand`
+
+Expected: all Jest suites pass.
+
+**Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: TypeScript exits 0.
+
+**Step 3: Run whitespace check**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+**Step 4: Review status**
+
+Run: `git status --short --branch`
+
+Expected: only intended Track B files changed.

--- a/src/coach/fixtures/structuredCoach.fixtures.ts
+++ b/src/coach/fixtures/structuredCoach.fixtures.ts
@@ -1,0 +1,167 @@
+import {
+  structuredCoachSchemaVersion,
+  type StructuredCoachOutput,
+} from '../schemas';
+
+const generatedAt = '2026-04-29T12:00:00.000Z';
+
+export const completeStructuredCoachOutputFixture: StructuredCoachOutput = {
+  schema_version: structuredCoachSchemaVersion,
+  generated_at: generatedAt,
+  goal_profile: {
+    primary_goal: 'endurance',
+    secondary_goals: ['general_fitness'],
+    motivation: 'Build consistent aerobic fitness.',
+    timeframe: 'next 8 weeks',
+    experience_level: 'recreational',
+    preferred_activities: ['run', 'walk', 'strength'],
+    disliked_activities: [],
+    constraints: ['avoid sudden mileage jumps'],
+    coaching_style: 'direct',
+    starting_strategy: 'Keep the first recommendation conservative until freshness improves.',
+    confidence: 0.72,
+    updated_at: generatedAt,
+  },
+  event_profile: {
+    event_intent: false,
+    event_name: null,
+    event_type: null,
+    event_date: null,
+    location: null,
+    distance_or_format: null,
+    missing_fields: [],
+    confidence: 0.4,
+  },
+  risk_flags: {
+    generated_at: generatedAt,
+    highest_severity: 'none',
+    has_blocking_risk: false,
+    summary: 'No risk flags were supplied in the current structured input.',
+    items: [
+      {
+        id: 'no-risk-reported',
+        category: 'other',
+        severity: 'none',
+        source: 'coach_service',
+        evidence: 'No pain, illness, injury, or severe fatigue signal was provided.',
+        recommendation_impact: 'none',
+        professional_care_guidance: null,
+        created_at: generatedAt,
+      },
+    ],
+  },
+  stale_data_report: {
+    generated_at: generatedAt,
+    stale_signals: ['training_load'],
+    missing_signals: ['daily_check_in'],
+    ignored_signals: ['stale training load'],
+    limitations: [
+      'Training load is unavailable until a source or local model provides it.',
+      'No same-day subjective check-in was supplied.',
+    ],
+  },
+  readiness_status: {
+    status: 'yellow',
+    confidence: 0.62,
+    score: 58,
+    signals_used: ['recent workouts', 'sleep duration', 'resting heart rate'],
+    stale_signals_ignored: ['training load'],
+    missing_signals: ['daily check-in'],
+    conservative_adjustment_reason:
+      'Freshness is mixed and there is no subjective check-in, so intensity should stay easy.',
+    summary: 'Mixed but usable readiness signals support an easy session.',
+  },
+  daily_recommendation: {
+    readiness_status: 'yellow',
+    short_explanation:
+      'Use today to build consistency without testing fitness because freshness is mixed.',
+    recommended_activity: {
+      title: 'Easy aerobic run',
+      activity_type: 'run',
+      intensity_target: 'easy',
+      duration_minutes: 35,
+      volume: 'Conversational pace only',
+      rationale: 'Easy aerobic work fits the goal while avoiding a load spike.',
+    },
+    easier_alternative: {
+      title: 'Walk plus mobility',
+      activity_type: 'walk',
+      intensity_target: 'recovery',
+      duration_minutes: 25,
+      volume: 'Relaxed walk and 5 minutes mobility',
+      rationale: 'This keeps momentum if subjective readiness is lower than the data suggests.',
+    },
+    what_to_avoid_today: ['hard intervals', 'testing max pace', 'large volume increase'],
+    confidence: 0.62,
+    sources_used: ['recent workouts', 'sleep duration', 'resting heart rate'],
+    sources_ignored: ['stale training load'],
+    check_in_question: 'Any pain, illness, unusual breathlessness, or severe fatigue today?',
+    risk_flags_applied: false,
+  },
+  health_check: {
+    generated_at: generatedAt,
+    known: ['Recent workout history exists', 'Some recovery signals are available'],
+    uncertain: ['Subjective soreness and energy are unknown'],
+    stale: ['Training load'],
+    missing: ['Daily check-in'],
+    risks: ['No risk flags supplied'],
+    summary_markdown:
+      'Readiness is usable but incomplete. Keep the recommendation easy and source-aware.',
+  },
+  inspection_notes: [
+    'Mock fixture is deterministic and does not require an OpenAI API key.',
+    'Issue 6 owns actual risk flag extraction and conservative override logic.',
+  ],
+};
+
+export const unknownReadinessStructuredCoachOutputFixture: StructuredCoachOutput = {
+  ...completeStructuredCoachOutputFixture,
+  readiness_status: {
+    status: 'unknown',
+    confidence: 0.35,
+    score: null,
+    signals_used: [],
+    stale_signals_ignored: [],
+    missing_signals: ['sleep', 'recent workouts', 'daily check-in', 'risk flag inputs'],
+    conservative_adjustment_reason:
+      'Missing inputs lower confidence and require a safer recommendation.',
+    summary: 'Readiness is unknown because there is not enough fresh data.',
+  },
+  daily_recommendation: {
+    ...completeStructuredCoachOutputFixture.daily_recommendation,
+    readiness_status: 'unknown',
+    short_explanation:
+      'Not enough fresh data is available, so choose a low-risk baseline option.',
+    recommended_activity: {
+      title: 'Baseline walk',
+      activity_type: 'walk',
+      intensity_target: 'recovery',
+      duration_minutes: 20,
+      volume: 'Relaxed pace',
+      rationale: 'Unknown readiness should not be treated as neutral.',
+    },
+    easier_alternative: {
+      title: 'Mobility reset',
+      activity_type: 'mobility',
+      intensity_target: 'recovery',
+      duration_minutes: 10,
+      volume: 'Gentle range of motion',
+      rationale: 'A shorter option is appropriate when confidence is low.',
+    },
+    what_to_avoid_today: ['hard efforts', 'new maxes', 'long sessions'],
+    confidence: 0.35,
+    sources_used: [],
+    sources_ignored: [],
+    check_in_question: 'How are sleep, soreness, energy, and pain today?',
+    risk_flags_applied: false,
+  },
+  health_check: {
+    ...completeStructuredCoachOutputFixture.health_check,
+    known: [],
+    uncertain: ['Current readiness'],
+    stale: [],
+    missing: ['Fresh wearable data', 'Daily check-in', 'Risk flag inputs'],
+    summary_markdown:
+      'Current readiness is unknown. Recommend a conservative baseline option.',
+  },
+};

--- a/src/coach/schemas.ts
+++ b/src/coach/schemas.ts
@@ -1,0 +1,531 @@
+export const structuredCoachSchemaVersion = '2026-04-29' as const;
+
+export const goalCategories = [
+  'general_fitness',
+  'body_composition',
+  'strength',
+  'endurance',
+  'event_preparation',
+  'return_to_training',
+  'health_and_energy',
+  'unknown',
+] as const;
+
+export const readinessStatuses = ['green', 'yellow', 'red', 'unknown'] as const;
+
+export const riskFlagSeverities = [
+  'none',
+  'low',
+  'moderate',
+  'high',
+  'urgent',
+] as const;
+
+export const riskFlagCategories = [
+  'pain',
+  'injury',
+  'illness',
+  'cardiovascular_symptom',
+  'respiratory_symptom',
+  'fainting',
+  'pregnancy_related',
+  'disordered_eating_signal',
+  'severe_fatigue',
+  'other',
+] as const;
+
+export const riskFlagSources = [
+  'goal_profile',
+  'event_profile',
+  'daily_check_in',
+  'typed_adjustment',
+  'health_data',
+  'coach_service',
+  'unknown',
+] as const;
+
+export const recommendationImpacts = [
+  'none',
+  'lower_confidence',
+  'reduce_intensity',
+  'recovery_only',
+  'professional_care',
+] as const;
+
+export const activityTypes = [
+  'rest',
+  'walk',
+  'run',
+  'ride',
+  'strength',
+  'mobility',
+  'mixed',
+  'unknown',
+] as const;
+
+export const intensityTargets = [
+  'recovery',
+  'easy',
+  'steady',
+  'moderate',
+  'hard',
+  'unknown',
+] as const;
+
+export type GoalCategory = (typeof goalCategories)[number];
+export type ReadinessStatusValue = (typeof readinessStatuses)[number];
+export type RiskFlagSeverity = (typeof riskFlagSeverities)[number];
+export type RiskFlagCategory = (typeof riskFlagCategories)[number];
+export type RiskFlagSource = (typeof riskFlagSources)[number];
+export type RecommendationImpact = (typeof recommendationImpacts)[number];
+export type ActivityType = (typeof activityTypes)[number];
+export type IntensityTarget = (typeof intensityTargets)[number];
+
+export type GoalProfile = {
+  primary_goal: GoalCategory;
+  secondary_goals: GoalCategory[];
+  motivation: string | null;
+  timeframe: string | null;
+  experience_level: 'beginner' | 'recreational' | 'advanced' | 'returning' | 'unknown';
+  preferred_activities: string[];
+  disliked_activities: string[];
+  constraints: string[];
+  coaching_style: 'direct' | 'supportive' | 'technical' | 'unknown';
+  starting_strategy: string;
+  confidence: number;
+  updated_at: string | null;
+};
+
+export type EventProfile = {
+  event_intent: boolean;
+  event_name: string | null;
+  event_type: string | null;
+  event_date: string | null;
+  location: string | null;
+  distance_or_format: string | null;
+  missing_fields: string[];
+  confidence: number;
+};
+
+export type RiskFlag = {
+  id: string;
+  category: RiskFlagCategory;
+  severity: RiskFlagSeverity;
+  source: RiskFlagSource;
+  evidence: string;
+  recommendation_impact: RecommendationImpact;
+  professional_care_guidance: string | null;
+  created_at: string;
+};
+
+export type RiskFlags = {
+  generated_at: string;
+  highest_severity: RiskFlagSeverity;
+  has_blocking_risk: boolean;
+  summary: string;
+  items: RiskFlag[];
+};
+
+export type StaleDataReport = {
+  generated_at: string;
+  stale_signals: string[];
+  missing_signals: string[];
+  ignored_signals: string[];
+  limitations: string[];
+};
+
+export type ReadinessStatus = {
+  status: ReadinessStatusValue;
+  confidence: number;
+  score: number | null;
+  signals_used: string[];
+  stale_signals_ignored: string[];
+  missing_signals: string[];
+  conservative_adjustment_reason: string | null;
+  summary: string;
+};
+
+export type RecommendationActivity = {
+  title: string;
+  activity_type: ActivityType;
+  intensity_target: IntensityTarget;
+  duration_minutes: number | null;
+  volume: string | null;
+  rationale: string;
+};
+
+export type DailyRecommendation = {
+  readiness_status: ReadinessStatusValue;
+  short_explanation: string;
+  recommended_activity: RecommendationActivity;
+  easier_alternative: RecommendationActivity;
+  what_to_avoid_today: string[];
+  confidence: number;
+  sources_used: string[];
+  sources_ignored: string[];
+  check_in_question: string;
+  risk_flags_applied: boolean;
+};
+
+export type HealthCheck = {
+  generated_at: string;
+  known: string[];
+  uncertain: string[];
+  stale: string[];
+  missing: string[];
+  risks: string[];
+  summary_markdown: string;
+};
+
+export type StructuredCoachOutput = {
+  schema_version: typeof structuredCoachSchemaVersion;
+  generated_at: string;
+  goal_profile: GoalProfile;
+  event_profile: EventProfile;
+  risk_flags: RiskFlags;
+  stale_data_report: StaleDataReport;
+  readiness_status: ReadinessStatus;
+  daily_recommendation: DailyRecommendation;
+  health_check: HealthCheck;
+  inspection_notes: string[];
+};
+
+type RecordValue = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function fail(path: string, message = 'is required'): never {
+  throw new Error(`${path} ${message}`);
+}
+
+function requireRecord(value: unknown, path: string): RecordValue {
+  if (value == null) {
+    return fail(path);
+  }
+  if (!isRecord(value)) {
+    return fail(path, 'must be an object');
+  }
+  return value;
+}
+
+function requireString(value: unknown, path: string): string {
+  if (value == null) {
+    return fail(path);
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return fail(path, 'must be a non-empty string');
+  }
+  return value;
+}
+
+function requireNullableString(value: unknown, path: string): string | null {
+  if (value === null) {
+    return null;
+  }
+  return requireString(value, path);
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (value == null) {
+    return fail(path);
+  }
+  if (typeof value !== 'boolean') {
+    return fail(path, 'must be a boolean');
+  }
+  return value;
+}
+
+function requireNumber(value: unknown, path: string): number {
+  if (value == null) {
+    return fail(path);
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fail(path, 'must be a finite number');
+  }
+  return value;
+}
+
+function requireNullableNumber(value: unknown, path: string): number | null {
+  if (value === null) {
+    return null;
+  }
+  return requireNumber(value, path);
+}
+
+function requireScore(value: unknown, path: string): number {
+  const score = requireNumber(value, path);
+  if (score < 0 || score > 1) {
+    return fail(path, 'must be between 0 and 1');
+  }
+  return score;
+}
+
+function requireStringArray(value: unknown, path: string): string[] {
+  if (value == null) {
+    return fail(path);
+  }
+  if (!Array.isArray(value)) {
+    return fail(path, 'must be an array');
+  }
+  return value.map((item, index) => requireString(item, `${path}[${index}]`));
+}
+
+function requireUnion<T extends readonly string[]>(
+  value: unknown,
+  path: string,
+  allowed: T,
+): T[number] {
+  if (value == null) {
+    return fail(path);
+  }
+  if (typeof value !== 'string' || !allowed.includes(value)) {
+    return fail(path, `must be one of ${allowed.join(', ')}`);
+  }
+  return value;
+}
+
+function parseGoalProfile(value: unknown): GoalProfile {
+  const profile = requireRecord(value, 'goal_profile');
+  return {
+    primary_goal: requireUnion(profile.primary_goal, 'goal_profile.primary_goal', goalCategories),
+    secondary_goals: requireStringArray(
+      profile.secondary_goals,
+      'goal_profile.secondary_goals',
+    ).map((goal, index) =>
+      requireUnion(goal, `goal_profile.secondary_goals[${index}]`, goalCategories),
+    ),
+    motivation: requireNullableString(profile.motivation, 'goal_profile.motivation'),
+    timeframe: requireNullableString(profile.timeframe, 'goal_profile.timeframe'),
+    experience_level: requireUnion(profile.experience_level, 'goal_profile.experience_level', [
+      'beginner',
+      'recreational',
+      'advanced',
+      'returning',
+      'unknown',
+    ] as const),
+    preferred_activities: requireStringArray(
+      profile.preferred_activities,
+      'goal_profile.preferred_activities',
+    ),
+    disliked_activities: requireStringArray(
+      profile.disliked_activities,
+      'goal_profile.disliked_activities',
+    ),
+    constraints: requireStringArray(profile.constraints, 'goal_profile.constraints'),
+    coaching_style: requireUnion(profile.coaching_style, 'goal_profile.coaching_style', [
+      'direct',
+      'supportive',
+      'technical',
+      'unknown',
+    ] as const),
+    starting_strategy: requireString(profile.starting_strategy, 'goal_profile.starting_strategy'),
+    confidence: requireScore(profile.confidence, 'goal_profile.confidence'),
+    updated_at: requireNullableString(profile.updated_at, 'goal_profile.updated_at'),
+  };
+}
+
+function parseEventProfile(value: unknown): EventProfile {
+  const profile = requireRecord(value, 'event_profile');
+  return {
+    event_intent: requireBoolean(profile.event_intent, 'event_profile.event_intent'),
+    event_name: requireNullableString(profile.event_name, 'event_profile.event_name'),
+    event_type: requireNullableString(profile.event_type, 'event_profile.event_type'),
+    event_date: requireNullableString(profile.event_date, 'event_profile.event_date'),
+    location: requireNullableString(profile.location, 'event_profile.location'),
+    distance_or_format: requireNullableString(
+      profile.distance_or_format,
+      'event_profile.distance_or_format',
+    ),
+    missing_fields: requireStringArray(profile.missing_fields, 'event_profile.missing_fields'),
+    confidence: requireScore(profile.confidence, 'event_profile.confidence'),
+  };
+}
+
+function parseRiskFlags(value: unknown): RiskFlags {
+  const flags = requireRecord(value, 'risk_flags');
+  const itemsValue = flags.items;
+
+  if (!Array.isArray(itemsValue)) {
+    fail('risk_flags.items', 'must be an array');
+  }
+
+  return {
+    generated_at: requireString(flags.generated_at, 'risk_flags.generated_at'),
+    highest_severity: requireUnion(
+      flags.highest_severity,
+      'risk_flags.highest_severity',
+      riskFlagSeverities,
+    ),
+    has_blocking_risk: requireBoolean(flags.has_blocking_risk, 'risk_flags.has_blocking_risk'),
+    summary: requireString(flags.summary, 'risk_flags.summary'),
+    items: itemsValue.map((item, index) => {
+      const flag = requireRecord(item, `risk_flags.items[${index}]`);
+      return {
+        id: requireString(flag.id, `risk_flags.items[${index}].id`),
+        category: requireUnion(
+          flag.category,
+          `risk_flags.items[${index}].category`,
+          riskFlagCategories,
+        ),
+        severity: requireUnion(
+          flag.severity,
+          `risk_flags.items[${index}].severity`,
+          riskFlagSeverities,
+        ),
+        source: requireUnion(
+          flag.source,
+          `risk_flags.items[${index}].source`,
+          riskFlagSources,
+        ),
+        evidence: requireString(flag.evidence, `risk_flags.items[${index}].evidence`),
+        recommendation_impact: requireUnion(
+          flag.recommendation_impact,
+          `risk_flags.items[${index}].recommendation_impact`,
+          recommendationImpacts,
+        ),
+        professional_care_guidance: requireNullableString(
+          flag.professional_care_guidance,
+          `risk_flags.items[${index}].professional_care_guidance`,
+        ),
+        created_at: requireString(flag.created_at, `risk_flags.items[${index}].created_at`),
+      };
+    }),
+  };
+}
+
+function parseStaleDataReport(value: unknown): StaleDataReport {
+  const report = requireRecord(value, 'stale_data_report');
+  return {
+    generated_at: requireString(report.generated_at, 'stale_data_report.generated_at'),
+    stale_signals: requireStringArray(report.stale_signals, 'stale_data_report.stale_signals'),
+    missing_signals: requireStringArray(
+      report.missing_signals,
+      'stale_data_report.missing_signals',
+    ),
+    ignored_signals: requireStringArray(
+      report.ignored_signals,
+      'stale_data_report.ignored_signals',
+    ),
+    limitations: requireStringArray(report.limitations, 'stale_data_report.limitations'),
+  };
+}
+
+function parseReadinessStatus(value: unknown): ReadinessStatus {
+  const readiness = requireRecord(value, 'readiness_status');
+  return {
+    status: requireUnion(readiness.status, 'readiness_status.status', readinessStatuses),
+    confidence: requireScore(readiness.confidence, 'readiness_status.confidence'),
+    score: requireNullableNumber(readiness.score, 'readiness_status.score'),
+    signals_used: requireStringArray(readiness.signals_used, 'readiness_status.signals_used'),
+    stale_signals_ignored: requireStringArray(
+      readiness.stale_signals_ignored,
+      'readiness_status.stale_signals_ignored',
+    ),
+    missing_signals: requireStringArray(
+      readiness.missing_signals,
+      'readiness_status.missing_signals',
+    ),
+    conservative_adjustment_reason: requireNullableString(
+      readiness.conservative_adjustment_reason,
+      'readiness_status.conservative_adjustment_reason',
+    ),
+    summary: requireString(readiness.summary, 'readiness_status.summary'),
+  };
+}
+
+function parseRecommendationActivity(value: unknown, path: string): RecommendationActivity {
+  const activity = requireRecord(value, path);
+  return {
+    title: requireString(activity.title, `${path}.title`),
+    activity_type: requireUnion(activity.activity_type, `${path}.activity_type`, activityTypes),
+    intensity_target: requireUnion(
+      activity.intensity_target,
+      `${path}.intensity_target`,
+      intensityTargets,
+    ),
+    duration_minutes: requireNullableNumber(activity.duration_minutes, `${path}.duration_minutes`),
+    volume: requireNullableString(activity.volume, `${path}.volume`),
+    rationale: requireString(activity.rationale, `${path}.rationale`),
+  };
+}
+
+function parseDailyRecommendation(value: unknown): DailyRecommendation {
+  const recommendation = requireRecord(value, 'daily_recommendation');
+  return {
+    readiness_status: requireUnion(
+      recommendation.readiness_status,
+      'daily_recommendation.readiness_status',
+      readinessStatuses,
+    ),
+    short_explanation: requireString(
+      recommendation.short_explanation,
+      'daily_recommendation.short_explanation',
+    ),
+    recommended_activity: parseRecommendationActivity(
+      recommendation.recommended_activity,
+      'daily_recommendation.recommended_activity',
+    ),
+    easier_alternative: parseRecommendationActivity(
+      recommendation.easier_alternative,
+      'daily_recommendation.easier_alternative',
+    ),
+    what_to_avoid_today: requireStringArray(
+      recommendation.what_to_avoid_today,
+      'daily_recommendation.what_to_avoid_today',
+    ),
+    confidence: requireScore(recommendation.confidence, 'daily_recommendation.confidence'),
+    sources_used: requireStringArray(
+      recommendation.sources_used,
+      'daily_recommendation.sources_used',
+    ),
+    sources_ignored: requireStringArray(
+      recommendation.sources_ignored,
+      'daily_recommendation.sources_ignored',
+    ),
+    check_in_question: requireString(
+      recommendation.check_in_question,
+      'daily_recommendation.check_in_question',
+    ),
+    risk_flags_applied: requireBoolean(
+      recommendation.risk_flags_applied,
+      'daily_recommendation.risk_flags_applied',
+    ),
+  };
+}
+
+function parseHealthCheck(value: unknown): HealthCheck {
+  const healthCheck = requireRecord(value, 'health_check');
+  return {
+    generated_at: requireString(healthCheck.generated_at, 'health_check.generated_at'),
+    known: requireStringArray(healthCheck.known, 'health_check.known'),
+    uncertain: requireStringArray(healthCheck.uncertain, 'health_check.uncertain'),
+    stale: requireStringArray(healthCheck.stale, 'health_check.stale'),
+    missing: requireStringArray(healthCheck.missing, 'health_check.missing'),
+    risks: requireStringArray(healthCheck.risks, 'health_check.risks'),
+    summary_markdown: requireString(healthCheck.summary_markdown, 'health_check.summary_markdown'),
+  };
+}
+
+export function parseStructuredCoachOutput(value: unknown): StructuredCoachOutput {
+  const output = requireRecord(value, 'structured_coach_output');
+  const schemaVersion = requireString(output.schema_version, 'schema_version');
+
+  if (schemaVersion !== structuredCoachSchemaVersion) {
+    fail('schema_version', `must be ${structuredCoachSchemaVersion}`);
+  }
+
+  return {
+    schema_version: structuredCoachSchemaVersion,
+    generated_at: requireString(output.generated_at, 'generated_at'),
+    goal_profile: parseGoalProfile(output.goal_profile),
+    event_profile: parseEventProfile(output.event_profile),
+    risk_flags: parseRiskFlags(output.risk_flags),
+    stale_data_report: parseStaleDataReport(output.stale_data_report),
+    readiness_status: parseReadinessStatus(output.readiness_status),
+    daily_recommendation: parseDailyRecommendation(output.daily_recommendation),
+    health_check: parseHealthCheck(output.health_check),
+    inspection_notes: requireStringArray(output.inspection_notes, 'inspection_notes'),
+  };
+}

--- a/src/coach/structuredCoach.test.ts
+++ b/src/coach/structuredCoach.test.ts
@@ -1,0 +1,60 @@
+import {
+  completeStructuredCoachOutputFixture,
+  unknownReadinessStructuredCoachOutputFixture,
+} from './fixtures/structuredCoach.fixtures';
+import { parseStructuredCoachOutput } from './schemas';
+import { createMockStructuredCoachService } from './structuredCoach';
+
+describe('structured coach output boundary', () => {
+  it('accepts a complete structured coach output fixture', () => {
+    const output = parseStructuredCoachOutput(completeStructuredCoachOutputFixture);
+
+    expect(output.risk_flags.highest_severity).toBe('none');
+    expect(output.readiness_status.status).toBe('yellow');
+    expect(output.daily_recommendation.easier_alternative.title).toContain('Walk');
+  });
+
+  it('rejects output with missing required risk flags', () => {
+    const { risk_flags: _riskFlags, ...missingRiskFlags } =
+      completeStructuredCoachOutputFixture;
+
+    expect(() => parseStructuredCoachOutput(missingRiskFlags)).toThrow(
+      'risk_flags is required',
+    );
+  });
+
+  it('rejects risk flag items missing severity', () => {
+    const output = {
+      ...completeStructuredCoachOutputFixture,
+      risk_flags: {
+        ...completeStructuredCoachOutputFixture.risk_flags,
+        highest_severity: 'moderate',
+        items: [
+          {
+            ...completeStructuredCoachOutputFixture.risk_flags.items[0],
+            severity: undefined,
+          },
+        ],
+      },
+    };
+
+    expect(() => parseStructuredCoachOutput(output)).toThrow(
+      'risk_flags.items[0].severity is required',
+    );
+  });
+
+  it('returns valid mock output without an API key', async () => {
+    const service = createMockStructuredCoachService({
+      output: unknownReadinessStructuredCoachOutputFixture,
+    });
+
+    const output = await service.generateDailyRecommendation({
+      generated_at: '2026-04-29T12:00:00.000Z',
+      user_message: 'What should I do today?',
+    });
+
+    expect(output.readiness_status.status).toBe('unknown');
+    expect(output.daily_recommendation.confidence).toBeLessThan(0.5);
+    expect(output.risk_flags.summary).toContain('No risk flags');
+  });
+});

--- a/src/coach/structuredCoach.ts
+++ b/src/coach/structuredCoach.ts
@@ -1,0 +1,43 @@
+import {
+  completeStructuredCoachOutputFixture,
+  unknownReadinessStructuredCoachOutputFixture,
+} from './fixtures/structuredCoach.fixtures';
+import {
+  parseStructuredCoachOutput,
+  type StructuredCoachOutput,
+} from './schemas';
+
+export type StructuredCoachRequest = {
+  generated_at: string;
+  user_message?: string;
+  goal_profile?: unknown;
+  event_profile?: unknown;
+  health_context?: unknown;
+};
+
+export type StructuredCoachService = {
+  generateDailyRecommendation(
+    request: StructuredCoachRequest,
+  ): Promise<StructuredCoachOutput>;
+};
+
+export type MockStructuredCoachServiceOptions = {
+  output?: unknown;
+};
+
+export function createMockStructuredCoachService(
+  options: MockStructuredCoachServiceOptions = {},
+): StructuredCoachService {
+  const output = options.output ?? completeStructuredCoachOutputFixture;
+
+  return {
+    async generateDailyRecommendation(_request) {
+      return parseStructuredCoachOutput(output);
+    },
+  };
+}
+
+export const mockStructuredCoachOutputs = {
+  complete: completeStructuredCoachOutputFixture,
+  unknownReadiness: unknownReadinessStructuredCoachOutputFixture,
+};


### PR DESCRIPTION
## Summary
- add Track B structured coach output schemas and runtime validators
- add mock structured coach service and deterministic fixtures
- update issue 6 so risk flag detection/override work extends the schema from issue 25

## Validation
- npm run test:ci
- npm run typecheck
- git diff --check