### PR TITLE
Track B health check markdown export

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,32 +1,57 @@
-import { StatusBar } from 'expo-status-bar';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Keyboard, KeyboardAvoidingView, Platform, SafeAreaView } from 'react-native';
+import { StatusBar } from "expo-status-bar";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+} from "react-native";
 
-import { openAiCoachModel, sendCoachMessage } from './src/ai/openaiCoach';
-import { generateTrainingPlan, resolveTrainingGoal } from './src/coach/planEngine';
-import { createCoachMessage, toOpenAiConversation } from './src/core/coachConversation';
-import { baselineRangeDays, emptyAppSettings, emptySnapshot } from './src/core/constants';
-import type { CoachConversationMessage, LastSync, SyncRuns, Tab } from './src/core/types';
-import { CoachOnboardingScreen } from './src/screens/CoachOnboardingScreen';
-import { CoachScreen } from './src/screens/CoachScreen';
-import { HistoryScreen } from './src/screens/HistoryScreen';
-import { SourceScreen } from './src/screens/SourceScreen';
-import { SplashScreen, StartLoadingScreen } from './src/screens/SplashScreen';
-import { WorkoutPlanScreen } from './src/screens/WorkoutPlanScreen';
-import { currentHealthProviderId, currentHealthProviderLabel, syncCurrentPlatform } from './src/health/syncPipeline';
-import type { PipelineSnapshot, SyncRange } from './src/health/types';
-import { formatRange, makeSyncRange } from './src/lib/dates';
+import { openAiCoachModel, sendCoachMessage } from "./src/ai/openaiCoach";
+import {
+  generateTrainingPlan,
+  resolveTrainingGoal,
+} from "./src/coach/planEngine";
+import {
+  createCoachMessage,
+  toOpenAiConversation,
+} from "./src/core/coachConversation";
+import {
+  baselineRangeDays,
+  emptyAppSettings,
+  emptySnapshot,
+} from "./src/core/constants";
+import type {
+  CoachConversationMessage,
+  LastSync,
+  SyncRuns,
+  Tab,
+} from "./src/core/types";
+import { CoachOnboardingScreen } from "./src/screens/CoachOnboardingScreen";
+import { CoachScreen } from "./src/screens/CoachScreen";
+import { HistoryScreen } from "./src/screens/HistoryScreen";
+import { SourceScreen } from "./src/screens/SourceScreen";
+import { SplashScreen, StartLoadingScreen } from "./src/screens/SplashScreen";
+import { WorkoutPlanScreen } from "./src/screens/WorkoutPlanScreen";
+import {
+  currentHealthProviderId,
+  currentHealthProviderLabel,
+  syncCurrentPlatform,
+} from "./src/health/syncPipeline";
+import type { PipelineSnapshot, SyncRange } from "./src/health/types";
+import { formatRange, makeSyncRange } from "./src/lib/dates";
 import {
   clearOpenAiApiKey,
   loadAppSettings,
   readOpenAiApiKey,
   saveAppSettings,
   saveOpenAiApiKey,
-} from './src/storage/appSettings';
-import type { AppSettings } from './src/storage/appSettings';
+} from "./src/storage/appSettings";
+import type { AppSettings } from "./src/storage/appSettings";
 import {
   clearPipeline,
-  exportPipelineJson,
+  exportPipelineArtifacts,
   getCoachHealthContext,
   getLastSyncRun,
   getLastSuccessfulSyncRun,
@@ -35,39 +60,50 @@ import {
   initTrainingStore,
   recordSyncRun,
   upsertSyncPayload,
-} from './src/storage/trainingStore';
-import { styles } from './src/styles/appStyles';
-import { TabBar } from './src/ui/TabBar';
+} from "./src/storage/trainingStore";
+import { styles } from "./src/styles/appStyles";
+import { TabBar } from "./src/ui/TabBar";
 
 export default function App() {
-  const [entryMode, setEntryMode] = useState<'splash' | 'onboarding' | 'loading-start' | 'app'>('splash');
-  const [activeTab, setActiveTab] = useState<Tab>('coach');
+  const [entryMode, setEntryMode] = useState<
+    "splash" | "onboarding" | "loading-start" | "app"
+  >("splash");
+  const [activeTab, setActiveTab] = useState<Tab>("coach");
   const [rangeDays, setRangeDays] = useState(baselineRangeDays);
   const [snapshot, setSnapshot] = useState<PipelineSnapshot>(emptySnapshot);
-  const [goalText, setGoalText] = useState('');
+  const [goalText, setGoalText] = useState("");
   const [lastSync, setLastSync] = useState<LastSync>(null);
   const [lastSuccessfulSync, setLastSuccessfulSync] = useState<LastSync>(null);
   const [recentSyncRuns, setRecentSyncRuns] = useState<SyncRuns>([]);
   const [appSettings, setAppSettings] = useState<AppSettings>(emptyAppSettings);
-  const [apiKeyDraft, setApiKeyDraft] = useState('');
-  const [coachDraft, setCoachDraft] = useState('');
-  const [coachMessages, setCoachMessages] = useState<CoachConversationMessage[]>([]);
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [coachDraft, setCoachDraft] = useState("");
+  const [coachMessages, setCoachMessages] = useState<
+    CoachConversationMessage[]
+  >([]);
   const [coachBusy, setCoachBusy] = useState(false);
   const [coachResponseId, setCoachResponseId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [settingsBusy, setSettingsBusy] = useState(false);
-  const [status, setStatus] = useState('Ready');
+  const [status, setStatus] = useState("Ready");
   const [warnings, setWarnings] = useState<string[]>([]);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [storeReady, setStoreReady] = useState(false);
   const bootstrapPromiseRef = useRef<Promise<void> | null>(null);
 
   const range = useMemo(() => makeSyncRange(rangeDays), [rangeDays]);
-  const canSync = Platform.OS === 'ios' || Platform.OS === 'android';
-  const sourceLabel = canSync ? currentHealthProviderLabel() : 'Apple Health / Health Connect';
+  const canSync = Platform.OS === "ios" || Platform.OS === "android";
+  const sourceLabel = canSync
+    ? currentHealthProviderLabel()
+    : "Apple Health / Health Connect";
 
   async function refreshStore() {
-    const [nextSnapshot, nextLastSync, nextLastSuccessfulSync, nextRecentSyncRuns] = await Promise.all([
+    const [
+      nextSnapshot,
+      nextLastSync,
+      nextLastSuccessfulSync,
+      nextRecentSyncRuns,
+    ] = await Promise.all([
       getPipelineSnapshot(),
       getLastSyncRun(),
       getLastSuccessfulSyncRun(),
@@ -87,7 +123,9 @@ export default function App() {
         setRangeDays(nextSettings.defaultSyncRangeDays);
         await refreshStore();
       })
-      .catch((error) => setStatus(String(error instanceof Error ? error.message : error)))
+      .catch((error) =>
+        setStatus(String(error instanceof Error ? error.message : error)),
+      )
       .finally(() => setStoreReady(true));
 
     bootstrapPromiseRef.current = bootstrap;
@@ -101,8 +139,12 @@ export default function App() {
   }
 
   useEffect(() => {
-    const showSubscription = Keyboard.addListener('keyboardDidShow', () => setKeyboardVisible(true));
-    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => setKeyboardVisible(false));
+    const showSubscription = Keyboard.addListener("keyboardDidShow", () =>
+      setKeyboardVisible(true),
+    );
+    const hideSubscription = Keyboard.addListener("keyboardDidHide", () =>
+      setKeyboardVisible(false),
+    );
 
     return () => {
       showSubscription.remove();
@@ -115,8 +157,8 @@ export default function App() {
     try {
       const nextSettings = await saveOpenAiApiKey(apiKeyDraft);
       setAppSettings(nextSettings);
-      setApiKeyDraft('');
-      setStatus('OpenAI API key saved locally');
+      setApiKeyDraft("");
+      setStatus("OpenAI API key saved locally");
     } catch (error) {
       setStatus(String(error instanceof Error ? error.message : error));
     } finally {
@@ -129,8 +171,8 @@ export default function App() {
     try {
       const nextSettings = await clearOpenAiApiKey();
       setAppSettings(nextSettings);
-      setApiKeyDraft('');
-      setStatus('OpenAI API key cleared');
+      setApiKeyDraft("");
+      setStatus("OpenAI API key cleared");
     } catch (error) {
       setStatus(String(error instanceof Error ? error.message : error));
     } finally {
@@ -141,10 +183,14 @@ export default function App() {
   async function setDefaultSyncRange(days: number) {
     setSettingsBusy(true);
     try {
-      const nextSettings = await saveAppSettings({ defaultSyncRangeDays: days });
+      const nextSettings = await saveAppSettings({
+        defaultSyncRangeDays: days,
+      });
       setAppSettings(nextSettings);
       setRangeDays(nextSettings.defaultSyncRangeDays);
-      setStatus(`Default sync range set to ${nextSettings.defaultSyncRangeDays}d`);
+      setStatus(
+        `Default sync range set to ${nextSettings.defaultSyncRangeDays}d`,
+      );
     } catch (error) {
       setStatus(String(error instanceof Error ? error.message : error));
     } finally {
@@ -159,22 +205,24 @@ export default function App() {
     }
 
     if (busy) {
-      setStatus('Wait for the current sync to finish before messaging the coach.');
+      setStatus(
+        "Wait for the current sync to finish before messaging the coach.",
+      );
       return;
     }
 
-    const userMessage = createCoachMessage('user', text);
+    const userMessage = createCoachMessage("user", text);
     const requestConversation = toOpenAiConversation(coachMessages);
 
-    setCoachDraft('');
+    setCoachDraft("");
 
     const apiKey = await readOpenAiApiKey();
     if (!apiKey) {
-      setStatus('Save an OpenAI API key in You before messaging the coach.');
+      setStatus("Save an OpenAI API key in You before messaging the coach.");
       setCoachMessages((messages) => [
         ...messages,
         userMessage,
-        createCoachMessage('coach', localCoachFallback(text)),
+        createCoachMessage("coach", localCoachFallback(text)),
       ]);
       return;
     }
@@ -185,8 +233,13 @@ export default function App() {
 
     try {
       const freshSnapshot = await getPipelineSnapshot();
-      const healthContext = await getCoachHealthContext({ rebuildDaily: false });
-      const plan = generateTrainingPlan(freshSnapshot, resolveTrainingGoal(goalText));
+      const healthContext = await getCoachHealthContext({
+        rebuildDaily: false,
+      });
+      const plan = generateTrainingPlan(
+        freshSnapshot,
+        resolveTrainingGoal(goalText),
+      );
       setSnapshot(freshSnapshot);
       const response = await sendCoachMessage({
         apiKey,
@@ -199,16 +252,21 @@ export default function App() {
         userMessage: text,
       });
       setCoachResponseId(response.responseId);
-      setCoachMessages((messages) => [...messages, createCoachMessage('coach', response.text)]);
+      setCoachMessages((messages) => [
+        ...messages,
+        createCoachMessage("coach", response.text),
+      ]);
       setStatus(`Coach answered with ${openAiCoachModel}`);
     } catch (error) {
       const message = String(error instanceof Error ? error.message : error);
-      const isLocalDatabaseError = message.toLowerCase().includes('database is locked');
+      const isLocalDatabaseError = message
+        .toLowerCase()
+        .includes("database is locked");
       setStatus(message);
       setCoachMessages((messages) => [
         ...messages,
         createCoachMessage(
-          'coach',
+          "coach",
           isLocalDatabaseError
             ? `I couldn't read the local health database. Wait for sync to finish, then try again. ${message}`
             : `I couldn't reach the OpenAI API. ${message}`,
@@ -222,30 +280,32 @@ export default function App() {
   function localCoachFallback(message: string): string {
     const normalized = message.toLowerCase();
     const mentionsPain =
-      normalized.includes('pain') ||
-      normalized.includes('sore') ||
-      normalized.includes('knee') ||
-      normalized.includes('niggle') ||
-      normalized.includes('injur');
+      normalized.includes("pain") ||
+      normalized.includes("sore") ||
+      normalized.includes("knee") ||
+      normalized.includes("niggle") ||
+      normalized.includes("injur");
     const mentionsFatigue =
-      normalized.includes('tired') ||
-      normalized.includes('fatigue') ||
-      normalized.includes('exhausted') ||
-      normalized.includes('sick') ||
-      normalized.includes('ill');
+      normalized.includes("tired") ||
+      normalized.includes("fatigue") ||
+      normalized.includes("exhausted") ||
+      normalized.includes("sick") ||
+      normalized.includes("ill");
 
     if (mentionsPain) {
-      return 'Yes. Put the knee first today: swap impact work for an easy walk, bike, or mobility session, and keep discomfort at a very low level. Stop if it is sharp, worsening, swollen, or changes your gait; if it persists, skip running and get it checked. Save an OpenAI API key in You when you want me to talk through the full plan trade-off properly.';
+      return "Yes. Put the knee first today: swap impact work for an easy walk, bike, or mobility session, and keep discomfort at a very low level. Stop if it is sharp, worsening, swollen, or changes your gait; if it persists, skip running and get it checked. Save an OpenAI API key in You when you want me to talk through the full plan trade-off properly.";
     }
 
     if (mentionsFatigue) {
-      return 'Yes. Treat that as useful context and downshift today: reduce duration, keep intensity easy, or move the session to tomorrow. The plan should adapt to how you feel, not just what the wearable says. Save an OpenAI API key in You when you want a proper back-and-forth on the broader plan.';
+      return "Yes. Treat that as useful context and downshift today: reduce duration, keep intensity easy, or move the session to tomorrow. The plan should adapt to how you feel, not just what the wearable says. Save an OpenAI API key in You when you want a proper back-and-forth on the broader plan.";
     }
 
-    return 'I have captured that context. The cards show the data, but this is the kind of detail I should use to adapt the plan. Save an OpenAI API key in You when you want a proper AI coaching conversation around it.';
+    return "I have captured that context. The cards show the data, but this is the kind of detail I should use to adapt the plan. Save an OpenAI API key in You when you want a proper AI coaching conversation around it.";
   }
 
-  function makeIncrementalSyncRange(lastSuccessful: LastSync): SyncRange | null {
+  function makeIncrementalSyncRange(
+    lastSuccessful: LastSync,
+  ): SyncRange | null {
     if (!lastSuccessful) {
       return null;
     }
@@ -265,21 +325,23 @@ export default function App() {
     return { startDate, endDate };
   }
 
-  async function runSync(syncType: 'manual' | 'incremental' = 'manual') {
+  async function runSync(syncType: "manual" | "incremental" = "manual") {
     await ensureStoreReady();
 
     if (!canSync) {
-      setStatus('Use an iOS or Android dev build.');
+      setStatus("Use an iOS or Android dev build.");
       return;
     }
 
     const provider = currentHealthProviderId();
     const startedAt = new Date().toISOString();
     const syncRange =
-      syncType === 'incremental' ? makeIncrementalSyncRange(lastSuccessfulSync) : range;
+      syncType === "incremental"
+        ? makeIncrementalSyncRange(lastSuccessfulSync)
+        : range;
 
     if (!syncRange) {
-      setStatus('Run a manual sync before incremental sync.');
+      setStatus("Run a manual sync before incremental sync.");
       return;
     }
 
@@ -290,21 +352,30 @@ export default function App() {
     try {
       const result = await syncCurrentPlatform(syncRange);
       const saved = await upsertSyncPayload(result);
-      await recordSyncRun(result.provider, syncRange, saved, startedAt, undefined, {
-        syncType,
-        healthSampleCount: result.samples.length,
-        workoutCount: result.workouts.length,
-        sleepSessionCount: result.sleepSessions.length,
-        nutritionDayCount: result.nutritionDaily.length,
-        warningCount: result.warnings.length,
-        diagnosticCount: result.diagnostics.length,
-      });
+      await recordSyncRun(
+        result.provider,
+        syncRange,
+        saved,
+        startedAt,
+        undefined,
+        {
+          syncType,
+          healthSampleCount: result.samples.length,
+          workoutCount: result.workouts.length,
+          sleepSessionCount: result.sleepSessions.length,
+          nutritionDayCount: result.nutritionDaily.length,
+          warningCount: result.warnings.length,
+          diagnosticCount: result.diagnostics.length,
+        },
+      );
       setWarnings(result.warnings);
       setStatus(`Synced ${saved.toLocaleString()} records`);
       await refreshStore();
     } catch (error) {
       if (provider) {
-        await recordSyncRun(provider, syncRange, 0, startedAt, error, { syncType });
+        await recordSyncRun(provider, syncRange, 0, startedAt, error, {
+          syncType,
+        });
       }
       setStatus(String(error instanceof Error ? error.message : error));
       await refreshStore();
@@ -314,20 +385,26 @@ export default function App() {
   }
 
   async function syncDataAndStart() {
-    setActiveTab('coach');
-    setEntryMode('loading-start');
-    setStatus(canSync ? `Loading data from ${sourceLabel}` : 'Opening local health store');
+    setActiveTab("coach");
+    setEntryMode("loading-start");
+    setStatus(
+      canSync
+        ? `Loading data from ${sourceLabel}`
+        : "Opening local health store",
+    );
 
     await ensureStoreReady();
     await runSync();
-    setEntryMode('app');
+    setEntryMode("app");
   }
 
   async function runExport() {
     setBusy(true);
     try {
-      const fileUri = await exportPipelineJson();
-      setStatus(`Exported ${fileUri.split('/').pop()}`);
+      const result = await exportPipelineArtifacts();
+      setStatus(
+        `Exported ${result.jsonFileUri.split("/").pop()} and ${result.healthCheckFileUri.split("/").pop()}`,
+      );
     } catch (error) {
       setStatus(String(error instanceof Error ? error.message : error));
     } finally {
@@ -336,45 +413,49 @@ export default function App() {
   }
 
   function confirmClear() {
-    Alert.alert('Clear local data', 'Remove imported records, rollups, and sync history?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Clear',
-        style: 'destructive',
-        onPress: () => {
-          void clearPipeline()
-            .then(refreshStore)
-            .then(() => setStatus('Local pipeline cleared'));
+    Alert.alert(
+      "Clear local data",
+      "Remove imported records, rollups, and sync history?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Clear",
+          style: "destructive",
+          onPress: () => {
+            void clearPipeline()
+              .then(refreshStore)
+              .then(() => setStatus("Local pipeline cleared"));
+          },
         },
-      },
-    ]);
+      ],
+    );
   }
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
         keyboardVerticalOffset={0}
         style={styles.appShell}
       >
-        {entryMode === 'splash' ? (
+        {entryMode === "splash" ? (
           <SplashScreen
             busy={!storeReady}
-            onStartOnboarding={() => setEntryMode('onboarding')}
+            onStartOnboarding={() => setEntryMode("onboarding")}
             onSyncAndStart={() => void syncDataAndStart()}
             sourceLabel={sourceLabel}
-            status={storeReady ? status : 'Opening local health store'}
+            status={storeReady ? status : "Opening local health store"}
           />
         ) : null}
-        {entryMode === 'onboarding' ? (
+        {entryMode === "onboarding" ? (
           <CoachOnboardingScreen
             busy={busy}
             canSync={canSync}
             onComplete={(nextGoal) => {
               setGoalText(nextGoal);
-              setEntryMode('app');
-              setActiveTab('coach');
+              setEntryMode("app");
+              setActiveTab("coach");
             }}
             onSync={runSync}
             sourceLabel={sourceLabel}
@@ -382,10 +463,10 @@ export default function App() {
             snapshot={snapshot}
           />
         ) : null}
-        {entryMode === 'loading-start' ? (
+        {entryMode === "loading-start" ? (
           <StartLoadingScreen sourceLabel={sourceLabel} status={status} />
         ) : null}
-        {entryMode === 'app' && activeTab === 'coach' ? (
+        {entryMode === "app" && activeTab === "coach" ? (
           <CoachScreen
             busy={busy}
             coachBusy={coachBusy}
@@ -396,20 +477,20 @@ export default function App() {
             lastSync={lastSync}
             onChangeCoachDraft={setCoachDraft}
             onSendCoachMessage={submitCoachMessage}
-            onOpenWorkout={() => setActiveTab('workout')}
+            onOpenWorkout={() => setActiveTab("workout")}
             onSync={runSync}
             snapshot={snapshot}
             status={status}
             warnings={warnings}
           />
         ) : null}
-        {entryMode === 'app' && activeTab === 'workout' ? (
+        {entryMode === "app" && activeTab === "workout" ? (
           <WorkoutPlanScreen goalText={goalText} snapshot={snapshot} />
         ) : null}
-        {entryMode === 'app' && activeTab === 'history' ? (
+        {entryMode === "app" && activeTab === "history" ? (
           <HistoryScreen goalText={goalText} snapshot={snapshot} />
         ) : null}
-        {entryMode === 'app' && activeTab === 'you' ? (
+        {entryMode === "app" && activeTab === "you" ? (
           <SourceScreen
             apiKeyDraft={apiKeyDraft}
             appSettings={appSettings}
@@ -419,7 +500,7 @@ export default function App() {
             onClear={confirmClear}
             onClearApiKey={removeApiKey}
             onExport={runExport}
-            onIncrementalSync={() => void runSync('incremental')}
+            onIncrementalSync={() => void runSync("incremental")}
             onSaveApiKey={saveApiKey}
             onSetDefaultRange={setDefaultSyncRange}
             onSync={runSync}
@@ -432,7 +513,7 @@ export default function App() {
             status={status}
           />
         ) : null}
-        {!keyboardVisible && entryMode === 'app' ? (
+        {!keyboardVisible && entryMode === "app" ? (
           <TabBar active={activeTab} onChange={setActiveTab} />
         ) : null}
       </KeyboardAvoidingView>

--- a/src/export/healthCheck.test.ts
+++ b/src/export/healthCheck.test.ts
@@ -1,0 +1,191 @@
+import type { PipelineSnapshot, SourceFreshness } from "../health/types";
+
+import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
+import { generateHealthCheckMarkdown } from "./healthCheck";
+
+const generatedAt = "2026-04-29T05:00:00.000Z";
+
+function source(
+  overrides: Partial<SourceFreshness> &
+    Pick<SourceFreshness, "domain" | "label">,
+): SourceFreshness {
+  return {
+    state: "fresh",
+    canonicalTypes: [],
+    sampleCount: 0,
+    dayCount: 0,
+    limitations: [],
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<PipelineSnapshot> = {}): PipelineSnapshot {
+  return {
+    totalSamples: 128,
+    workoutCount: 4,
+    sleepCount: 6,
+    nutritionDays: 5,
+    coverageDays: 14,
+    metricAvailability: [],
+    sourceFreshness: [
+      source({
+        domain: "sleep",
+        label: "Sleep",
+        state: "fresh",
+        sampleCount: 6,
+        dayCount: 6,
+        latestLocalDate: "2026-04-29",
+      }),
+      source({
+        domain: "workouts",
+        label: "Workouts",
+        state: "stale",
+        sampleCount: 2,
+        dayCount: 2,
+        latestLocalDate: "2026-04-24",
+        ageDays: 5,
+        limitations: ["No workout import has completed this week."],
+      }),
+      source({
+        domain: "steps",
+        label: "Steps",
+        state: "partial",
+        sampleCount: 14,
+        dayCount: 7,
+        latestLocalDate: "2026-04-29",
+        limitations: ["Today is still in progress."],
+      }),
+      source({
+        domain: "check_ins",
+        label: "Check-ins",
+        state: "missing",
+        limitations: [
+          "Daily check-ins are not implemented in local storage yet.",
+        ],
+      }),
+    ],
+    latestDiagnostics: [],
+    today: {
+      date: "2026-04-29",
+      dataCompleteness: "partial",
+      wellnessDataStatus: "Watch data without nutrition",
+      sourceCount: 3,
+      hasPlatformWellness: true,
+      hasActivity: true,
+      hasNutrition: false,
+      hasSleep: true,
+      hasSteps: true,
+      hasEnergy: true,
+      steps: 6400,
+      activeKcal: 410,
+      sleepSeconds: 7 * 3600,
+      restingHr: 52,
+      hrvLastNightAvg: 48,
+      workoutCount: 0,
+      generatedAt,
+    },
+    history: [],
+    recentWorkouts: [],
+    recentSamples: [],
+    trainingLoad: buildTrainingLoadSnapshot(),
+    recommendation: {
+      readiness: 62,
+      readinessLabel: "Yellow",
+      color: "warm",
+      title: "Keep it easy",
+      detail: "Easy aerobic session only.",
+      reason: "Freshness is mixed.",
+      opener: "Use the current data conservatively.",
+      strain: 5,
+      strainTarget: "4-6",
+    },
+    ...overrides,
+  };
+}
+
+describe("generateHealthCheckMarkdown", () => {
+  it("summarizes known, uncertain, stale, risky, and missing local data", () => {
+    const markdown = generateHealthCheckMarkdown(snapshot(), { generatedAt });
+
+    expect(markdown).toContain("# health_check.md");
+    expect(markdown).toContain("Generated at: 2026-04-29T05:00:00.000Z");
+    expect(markdown).toContain("## Known");
+    expect(markdown).toContain(
+      "- Pipeline coverage: 14 days, 128 samples, 4 workouts, 6 sleep days, 5 nutrition days.",
+    );
+    expect(markdown).toContain(
+      "- Today: 2026-04-29, partial completeness, 3 active source domains.",
+    );
+    expect(markdown).toContain(
+      "- Readiness estimate: Yellow (62/100), target strain 4-6.",
+    );
+    expect(markdown).toContain("## Source Coverage");
+    expect(markdown).toContain(
+      "- Sleep: fresh; latest 2026-04-29; 6 days; 6 samples.",
+    );
+    expect(markdown).toContain(
+      "- Workouts: stale; latest 2026-04-24; 2 days; 2 samples; age 5 days.",
+    );
+    expect(markdown).toContain("## Uncertain");
+    expect(markdown).toContain(
+      "- Steps is partial: Today is still in progress.",
+    );
+    expect(markdown).toContain(
+      "- Today is partial, so current-day totals may change after the next sync.",
+    );
+    expect(markdown).toContain("## Stale");
+    expect(markdown).toContain(
+      "- Workouts last updated on 2026-04-24, 5 days ago: No workout import has completed this week.",
+    );
+    expect(markdown).toContain("## Risky");
+    expect(markdown).toContain(
+      "- Stale or missing domains reduce confidence; avoid using this export as proof of current readiness.",
+    );
+    expect(markdown).toContain(
+      "- No daily check-in is available; subjective fatigue, soreness, pain, illness, and motivation are unknown.",
+    );
+    expect(markdown).toContain("## Missing");
+    expect(markdown).toContain(
+      "- Check-ins is missing: Daily check-ins are not implemented in local storage yet.",
+    );
+    expect(markdown).not.toMatch(
+      /\b(diagnose|diagnosis|treatment|prescribe|prescription|disease)\b/i,
+    );
+  });
+
+  it("reports an empty snapshot without inventing available data", () => {
+    const markdown = generateHealthCheckMarkdown(
+      snapshot({
+        totalSamples: 0,
+        workoutCount: 0,
+        sleepCount: 0,
+        nutritionDays: 0,
+        coverageDays: 0,
+        sourceFreshness: [],
+        today: null,
+        recommendation: {
+          readiness: null,
+          readinessLabel: "Unknown",
+          color: "neutral",
+          title: "Connect data",
+          detail: "No local data yet.",
+          reason: "No platform data is available.",
+          opener: "Connect a health source.",
+          strain: 0,
+          strainTarget: "0",
+        },
+      }),
+      { generatedAt },
+    );
+
+    expect(markdown).toContain(
+      "- Pipeline coverage: no local health data is available.",
+    );
+    expect(markdown).toContain("- Today: no daily rollup is available.");
+    expect(markdown).toContain("- Source freshness rows are unavailable.");
+    expect(markdown).toContain("- No source coverage dates are available.");
+    expect(markdown).toContain(
+      "- Local health data is missing; recommendations should stay conservative.",
+    );
+  });
+});

--- a/src/export/healthCheck.ts
+++ b/src/export/healthCheck.ts
@@ -1,0 +1,212 @@
+import type { PipelineSnapshot, SourceFreshness } from "../health/types";
+
+export type HealthCheckMarkdownOptions = {
+  generatedAt?: string | Date;
+};
+
+function isoString(value: string | Date | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value ?? new Date().toISOString();
+}
+
+function countLabel(
+  count: number,
+  singular: string,
+  plural = `${singular}s`,
+): string {
+  return `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
+}
+
+function fallbackDetail(source: SourceFreshness): string {
+  switch (source.state) {
+    case "missing":
+      return "No local data is available for this domain.";
+    case "partial":
+      return "Coverage is incomplete for this domain.";
+    case "stale":
+      return "The latest local data is older than the freshness window.";
+    case "fresh":
+    default:
+      return "No limitation was recorded.";
+  }
+}
+
+function sourceDetail(source: SourceFreshness): string {
+  return source.limitations.length
+    ? source.limitations.join(" ")
+    : fallbackDetail(source);
+}
+
+function sourceCoverageLine(source: SourceFreshness): string {
+  const latest = source.latestLocalDate ?? "no latest date";
+  const age =
+    source.ageDays == null ? "" : `; age ${countLabel(source.ageDays, "day")}`;
+
+  return `- ${source.label}: ${source.state}; latest ${latest}; ${countLabel(
+    source.dayCount,
+    "day",
+  )}; ${countLabel(source.sampleCount, "sample")}${age}.`;
+}
+
+function staleLine(source: SourceFreshness): string {
+  const latest = source.latestLocalDate
+    ? `${source.label} last updated on ${source.latestLocalDate}`
+    : `${source.label} has no latest local date`;
+  const age =
+    source.ageDays == null ? "" : `, ${countLabel(source.ageDays, "day")} ago`;
+
+  return `- ${latest}${age}: ${sourceDetail(source)}`;
+}
+
+function missingLine(source: SourceFreshness): string {
+  return `- ${source.label} is missing: ${sourceDetail(source)}`;
+}
+
+function partialLine(source: SourceFreshness): string {
+  return `- ${source.label} is partial: ${sourceDetail(source)}`;
+}
+
+function missingCheckIns(sourceFreshness: SourceFreshness[]): boolean {
+  return sourceFreshness.some(
+    (source) => source.domain === "check_ins" && source.state === "missing",
+  );
+}
+
+function hasLocalHealthData(snapshot: PipelineSnapshot): boolean {
+  return Boolean(
+    snapshot.totalSamples ||
+    snapshot.workoutCount ||
+    snapshot.sleepCount ||
+    snapshot.nutritionDays ||
+    snapshot.coverageDays,
+  );
+}
+
+function section(title: string, lines: string[]): string[] {
+  return [`## ${title}`, ...lines, ""];
+}
+
+export function generateHealthCheckMarkdown(
+  snapshot: PipelineSnapshot,
+  options: HealthCheckMarkdownOptions = {},
+): string {
+  const generatedAt = isoString(options.generatedAt);
+  const localDataAvailable = hasLocalHealthData(snapshot);
+  const partialSources = snapshot.sourceFreshness.filter(
+    (source) => source.state === "partial",
+  );
+  const staleSources = snapshot.sourceFreshness.filter(
+    (source) => source.state === "stale",
+  );
+  const missingSources = snapshot.sourceFreshness.filter(
+    (source) => source.state === "missing",
+  );
+
+  const known: string[] = localDataAvailable
+    ? [
+        `- Pipeline coverage: ${countLabel(snapshot.coverageDays, "day")}, ${countLabel(
+          snapshot.totalSamples,
+          "sample",
+        )}, ${countLabel(snapshot.workoutCount, "workout")}, ${countLabel(
+          snapshot.sleepCount,
+          "sleep day",
+        )}, ${countLabel(snapshot.nutritionDays, "nutrition day")}.`,
+      ]
+    : ["- Pipeline coverage: no local health data is available."];
+
+  if (snapshot.today) {
+    known.push(
+      `- Today: ${snapshot.today.date}, ${snapshot.today.dataCompleteness} completeness, ${countLabel(
+        snapshot.today.sourceCount,
+        "active source domain",
+      )}.`,
+    );
+  } else {
+    known.push("- Today: no daily rollup is available.");
+  }
+
+  const readiness = snapshot.recommendation.readiness;
+  const readinessScore = readiness == null ? "" : ` (${readiness}/100)`;
+  known.push(
+    `- Readiness estimate: ${snapshot.recommendation.readinessLabel}${readinessScore}, target strain ${snapshot.recommendation.strainTarget}.`,
+  );
+
+  const sourceCoverage = snapshot.sourceFreshness.length
+    ? snapshot.sourceFreshness.map(sourceCoverageLine)
+    : ["- Source freshness rows are unavailable."];
+
+  const uncertain = partialSources.map(partialLine);
+  if (!snapshot.sourceFreshness.length) {
+    uncertain.push("- Source freshness rows are unavailable.");
+  }
+  if (snapshot.today?.dataCompleteness === "partial") {
+    uncertain.push(
+      "- Today is partial, so current-day totals may change after the next sync.",
+    );
+  }
+  if (snapshot.recommendation.readiness == null) {
+    uncertain.push("- Readiness estimate is unknown from local data.");
+  }
+  if (!uncertain.length) {
+    uncertain.push(
+      "- No uncertainty flags were found in local snapshot metadata.",
+    );
+  }
+
+  const stale = staleSources.length
+    ? staleSources.map(staleLine)
+    : ["- No stale domains were reported."];
+
+  const risky: string[] = [];
+  if (staleSources.length || missingSources.length) {
+    risky.push(
+      "- Stale or missing domains reduce confidence; avoid using this export as proof of current readiness.",
+    );
+  }
+  if (missingCheckIns(snapshot.sourceFreshness)) {
+    risky.push(
+      "- No daily check-in is available; subjective fatigue, soreness, pain, illness, and motivation are unknown.",
+    );
+  }
+  if (!localDataAvailable) {
+    risky.push(
+      "- Local health data is missing; recommendations should stay conservative.",
+    );
+  }
+  if (!risky.length) {
+    risky.push("- No local risk-confidence flags were found.");
+  }
+
+  const missing = missingSources.map(missingLine);
+  if (!snapshot.sourceFreshness.length) {
+    missing.push("- No source coverage dates are available.");
+  }
+  if (!localDataAvailable) {
+    missing.push(
+      "- Local health data is missing; recommendations should stay conservative.",
+    );
+  }
+  if (!missing.length) {
+    missing.push("- No missing source domains were reported.");
+  }
+
+  const lines = [
+    "# health_check.md",
+    "",
+    `Generated at: ${generatedAt}`,
+    "",
+    "This file is generated locally from the pipeline snapshot. It summarizes data coverage and confidence only.",
+    "",
+    ...section("Known", known),
+    ...section("Source Coverage", sourceCoverage),
+    ...section("Uncertain", uncertain),
+    ...section("Stale", stale),
+    ...section("Risky", risky),
+    ...section("Missing", missing),
+  ];
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/src/export/pipelineExport.test.ts
+++ b/src/export/pipelineExport.test.ts
@@ -1,0 +1,48 @@
+import type { PipelineSnapshot } from "../health/types";
+
+import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
+import { buildPipelineExportArtifacts } from "./pipelineExport";
+
+function snapshot(): PipelineSnapshot {
+  return {
+    totalSamples: 0,
+    workoutCount: 0,
+    sleepCount: 0,
+    nutritionDays: 0,
+    coverageDays: 0,
+    metricAvailability: [],
+    sourceFreshness: [],
+    latestDiagnostics: [],
+    today: null,
+    history: [],
+    recentWorkouts: [],
+    recentSamples: [],
+    trainingLoad: buildTrainingLoadSnapshot(),
+    recommendation: {
+      readiness: null,
+      readinessLabel: "Unknown",
+      color: "neutral",
+      title: "Connect data",
+      detail: "No local data yet.",
+      reason: "No platform data is available.",
+      opener: "Connect a health source.",
+      strain: 0,
+      strainTarget: "0",
+    },
+  };
+}
+
+describe("buildPipelineExportArtifacts", () => {
+  it("uses stable artifact names and the export timestamp for health_check.md", () => {
+    const artifacts = buildPipelineExportArtifacts(snapshot(), {
+      exportedAt: "2026-04-29T05:00:00.000Z",
+      timestamp: 123,
+    });
+
+    expect(artifacts.jsonFileName).toBe("biostream-pipeline-123.json");
+    expect(artifacts.healthCheckFileName).toBe("health_check-123.md");
+    expect(artifacts.healthCheckMarkdown).toContain(
+      "Generated at: 2026-04-29T05:00:00.000Z",
+    );
+  });
+});

--- a/src/export/pipelineExport.ts
+++ b/src/export/pipelineExport.ts
@@ -1,0 +1,39 @@
+import type { PipelineSnapshot } from "../health/types";
+import { generateHealthCheckMarkdown } from "./healthCheck";
+
+export type PipelineExportArtifactOptions = {
+  exportedAt?: string | Date;
+  timestamp?: number;
+};
+
+export type PipelineExportArtifacts = {
+  exportedAt: string;
+  jsonFileName: string;
+  healthCheckFileName: string;
+  healthCheckMarkdown: string;
+};
+
+function isoString(value: string | Date | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value ?? new Date().toISOString();
+}
+
+export function buildPipelineExportArtifacts(
+  snapshot: PipelineSnapshot,
+  options: PipelineExportArtifactOptions = {},
+): PipelineExportArtifacts {
+  const exportedAt = isoString(options.exportedAt);
+  const timestamp = options.timestamp ?? Date.now();
+
+  return {
+    exportedAt,
+    jsonFileName: `biostream-pipeline-${timestamp}.json`,
+    healthCheckFileName: `health_check-${timestamp}.md`,
+    healthCheckMarkdown: generateHealthCheckMarkdown(snapshot, {
+      generatedAt: exportedAt,
+    }),
+  };
+}

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -17,6 +17,7 @@ import {
   type PrimaryGoal,
   type StartingStrategy,
 } from "../goals/goalProfile";
+import { buildPipelineExportArtifacts } from "../export/pipelineExport";
 import { formatDuration, localDateKey } from "../lib/dates";
 import { safeJsonStringify } from "../lib/json";
 import {
@@ -139,6 +140,11 @@ export type SyncRunDetails = {
   nutritionDayCount?: number;
   warningCount?: number;
   diagnosticCount?: number;
+};
+
+export type PipelineExportResult = {
+  jsonFileUri: string;
+  healthCheckFileUri: string;
 };
 
 type HealthConnectDiagnosticRow = {
@@ -2601,7 +2607,8 @@ function deriveRecommendation(
   let readiness = 56;
   const signals: string[] = [];
   const freshnessGaps = recommendationFreshnessGaps(sourceFreshness);
-  const trainingLoadBoundary = recommendationBoundaryForTrainingLoad(trainingLoad);
+  const trainingLoadBoundary =
+    recommendationBoundaryForTrainingLoad(trainingLoad);
 
   if (current.sleepSeconds != null) {
     if (sleepHours >= 7.5) {
@@ -2839,7 +2846,12 @@ export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {
         sourceModifiedAt: row.source_modified_at ?? undefined,
       })),
       trainingLoad,
-      recommendation: deriveRecommendation(today, history, sourceFreshness, trainingLoad),
+      recommendation: deriveRecommendation(
+        today,
+        history,
+        sourceFreshness,
+        trainingLoad,
+      ),
     };
   });
 }
@@ -3094,7 +3106,9 @@ export async function clearPipeline(): Promise<void> {
   });
 }
 
-export async function exportPipelineJson(): Promise<string> {
+export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
+  const pipelineSnapshot = await getPipelineSnapshot();
+
   return withStorageLock(async () => {
     const db = await getDb();
     const samples = await db.getAllAsync<HealthSampleRow>(
@@ -3122,16 +3136,14 @@ export async function exportPipelineJson(): Promise<string> {
     const goalProfileRow = await db.getFirstAsync<GoalProfileRow>(
       "SELECT * FROM goal_profile WHERE id = 'current' LIMIT 1",
     );
-    const exportedAt = new Date().toISOString();
+    const exportArtifacts = buildPipelineExportArtifacts(pipelineSnapshot);
+    const exportedAt = exportArtifacts.exportedAt;
     const goalProfile = goalProfileRow ? toGoalProfile(goalProfileRow) : null;
     const riskFlags = extractRiskFlagsFromCoachRequest({
       generated_at: exportedAt,
       goal_profile: goalProfile ?? undefined,
     });
 
-    const trainingLoad = buildCurrentTrainingLoadSnapshot(
-      dedupeWorkoutRows(workouts).length,
-    );
     const payload = {
       schema: "biostream_training_pipeline.v5",
       exportedAt,
@@ -3145,7 +3157,7 @@ export async function exportPipelineJson(): Promise<string> {
       diagnostics,
       goalProfile,
       riskFlags,
-      trainingLoad: toTrainingLoadExport(trainingLoad),
+      trainingLoad: toTrainingLoadExport(pipelineSnapshot.trainingLoad),
     };
 
     const directory = FileSystem.documentDirectory;
@@ -3155,18 +3167,37 @@ export async function exportPipelineJson(): Promise<string> {
       );
     }
 
-    const fileUri = `${directory}biostream-pipeline-${Date.now()}.json`;
-    await FileSystem.writeAsStringAsync(fileUri, safeJsonStringify(payload), {
-      encoding: FileSystem.EncodingType.UTF8,
-    });
+    const jsonFileUri = `${directory}${exportArtifacts.jsonFileName}`;
+    const healthCheckFileUri = `${directory}${exportArtifacts.healthCheckFileName}`;
+    await Promise.all([
+      FileSystem.writeAsStringAsync(jsonFileUri, safeJsonStringify(payload), {
+        encoding: FileSystem.EncodingType.UTF8,
+      }),
+      FileSystem.writeAsStringAsync(
+        healthCheckFileUri,
+        exportArtifacts.healthCheckMarkdown,
+        {
+          encoding: FileSystem.EncodingType.UTF8,
+        },
+      ),
+    ]);
 
     if (await Sharing.isAvailableAsync()) {
-      await Sharing.shareAsync(fileUri, {
+      await Sharing.shareAsync(jsonFileUri, {
         mimeType: "application/json",
         dialogTitle: "Export BioStream pipeline JSON",
       });
+      await Sharing.shareAsync(healthCheckFileUri, {
+        mimeType: "text/markdown",
+        dialogTitle: "Export BioStream health_check.md",
+      });
     }
 
-    return fileUri;
+    return { jsonFileUri, healthCheckFileUri };
   });
+}
+
+export async function exportPipelineJson(): Promise<string> {
+  const result = await exportPipelineArtifacts();
+  return result.jsonFileUri;
 }

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -8,14 +8,15 @@ import type {
   SourceFreshness,
   SyncPayload,
   SyncRange,
-} from '../health/types';
-import { emptySnapshot } from '../core/constants';
-import { buildTrainingLoadSnapshot } from '../coach/trainingLoad';
+} from "../health/types";
+import { emptySnapshot } from "../core/constants";
+import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
+import { buildPipelineExportArtifacts } from "../export/pipelineExport";
 import {
   normalizeGoalProfile,
   type GoalProfile,
   type GoalProfileDraft,
-} from '../goals/goalProfile';
+} from "../goals/goalProfile";
 
 export type HealthSampleRow = {
   sample_id: string;
@@ -30,7 +31,7 @@ export type HealthSampleRow = {
   timezone: string | null;
   value: number | null;
   unit: string | null;
-  hrv_method: 'rmssd' | 'sdnn' | null;
+  hrv_method: "rmssd" | "sdnn" | null;
   metadata_json: string;
   source_modified_at: string | null;
   imported_at: string;
@@ -45,7 +46,7 @@ export type WorkoutRow = {
   local_date: string;
   name: string | null;
   activity_type: string | null;
-  sport_bucket: 'run' | 'ride' | 'strength' | 'swim' | 'walk' | 'other';
+  sport_bucket: "run" | "ride" | "strength" | "swim" | "walk" | "other";
   elapsed_seconds: number;
   moving_seconds: number | null;
   distance_km: number | null;
@@ -63,7 +64,7 @@ export type WorkoutRow = {
 export type SyncRunRow = {
   id: number;
   provider: HealthProvider;
-  sync_type: 'manual' | 'incremental';
+  sync_type: "manual" | "incremental";
   started_at: string;
   ended_at: string;
   range_start: string;
@@ -75,18 +76,23 @@ export type SyncRunRow = {
   nutrition_day_count: number;
   warning_count: number;
   diagnostic_count: number;
-  status: 'ok' | 'error';
+  status: "ok" | "error";
   error: string | null;
 };
 
 export type SyncRunDetails = {
-  syncType?: SyncRunRow['sync_type'];
+  syncType?: SyncRunRow["sync_type"];
   healthSampleCount?: number;
   workoutCount?: number;
   sleepSessionCount?: number;
   nutritionDayCount?: number;
   warningCount?: number;
   diagnosticCount?: number;
+};
+
+export type PipelineExportResult = {
+  jsonFileUri: string;
+  healthCheckFileUri: string;
 };
 
 const dayMs = 24 * 60 * 60 * 1000;
@@ -98,8 +104,8 @@ function dateKey(offset = 0) {
 function day(offset = 0): DailyMetrics {
   return {
     date: dateKey(offset),
-    dataCompleteness: 'full',
-    wellnessDataStatus: 'Watch, sleep, workouts',
+    dataCompleteness: "full",
+    wellnessDataStatus: "Watch, sleep, workouts",
     sourceCount: 4,
     hasPlatformWellness: true,
     hasActivity: true,
@@ -111,7 +117,8 @@ function day(offset = 0): DailyMetrics {
     activeKcal: 520 - Math.abs(offset) * 12,
     totalKcal: 2240,
     distanceKm: 6.8,
-    sleepSeconds: offset === 0 ? 7.4 * 3600 : (7 + Math.abs(offset % 2) * 0.4) * 3600,
+    sleepSeconds:
+      offset === 0 ? 7.4 * 3600 : (7 + Math.abs(offset % 2) * 0.4) * 3600,
     timeInBedSeconds: 8 * 3600,
     sleepEfficiency: 0.91,
     restingHr: 51 + Math.abs(offset % 3),
@@ -119,10 +126,10 @@ function day(offset = 0): DailyMetrics {
     heartRateMinBpm: 45,
     heartRateMaxBpm: 161,
     hrvLastNightAvg: offset === 0 ? 62 : 56 + Math.abs(offset),
-    hrvMethod: 'rmssd',
-    hrvCanonicalType: 'hrv_rmssd',
-    hrvSourceApp: 'Apple Watch',
-    hrvSourceKey: 'Apple Watch',
+    hrvMethod: "rmssd",
+    hrvCanonicalType: "hrv_rmssd",
+    hrvSourceApp: "Apple Watch",
+    hrvSourceKey: "Apple Watch",
     hrvSampleCount: 1,
     workoutCount: offset === -1 || offset === -3 ? 1 : 0,
     runWorkoutCount: offset === -1 ? 1 : 0,
@@ -147,52 +154,82 @@ const history = Array.from({ length: 14 }, (_, index) => day(-index));
 const latestDate = dateKey(0);
 
 const demoMetricAvailability: MetricAvailability[] = [
-  { canonicalType: 'sleep_session', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'hrv_rmssd', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'resting_heart_rate', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'heart_rate', sampleCount: 96, dayCount: 14, latestDate },
-  { canonicalType: 'workout', sampleCount: 9, dayCount: 7, latestDate: dateKey(-1) },
-  { canonicalType: 'steps', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'active_energy', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'distance', sampleCount: 14, dayCount: 14, latestDate },
-  { canonicalType: 'nutrition', sampleCount: 8, dayCount: 8, latestDate },
-  { canonicalType: 'hydration', sampleCount: 8, dayCount: 8, latestDate },
-  { canonicalType: 'weight', sampleCount: 4, dayCount: 4, latestDate: dateKey(-1) },
-  { canonicalType: 'body_fat', sampleCount: 4, dayCount: 4, latestDate: dateKey(-1) },
-  { canonicalType: 'lean_body_mass', sampleCount: 4, dayCount: 4, latestDate: dateKey(-1) },
-  { canonicalType: 'vo2max', sampleCount: 2, dayCount: 2, latestDate: dateKey(-2) },
+  { canonicalType: "sleep_session", sampleCount: 14, dayCount: 14, latestDate },
+  { canonicalType: "hrv_rmssd", sampleCount: 14, dayCount: 14, latestDate },
+  {
+    canonicalType: "resting_heart_rate",
+    sampleCount: 14,
+    dayCount: 14,
+    latestDate,
+  },
+  { canonicalType: "heart_rate", sampleCount: 96, dayCount: 14, latestDate },
+  {
+    canonicalType: "workout",
+    sampleCount: 9,
+    dayCount: 7,
+    latestDate: dateKey(-1),
+  },
+  { canonicalType: "steps", sampleCount: 14, dayCount: 14, latestDate },
+  { canonicalType: "active_energy", sampleCount: 14, dayCount: 14, latestDate },
+  { canonicalType: "distance", sampleCount: 14, dayCount: 14, latestDate },
+  { canonicalType: "nutrition", sampleCount: 8, dayCount: 8, latestDate },
+  { canonicalType: "hydration", sampleCount: 8, dayCount: 8, latestDate },
+  {
+    canonicalType: "weight",
+    sampleCount: 4,
+    dayCount: 4,
+    latestDate: dateKey(-1),
+  },
+  {
+    canonicalType: "body_fat",
+    sampleCount: 4,
+    dayCount: 4,
+    latestDate: dateKey(-1),
+  },
+  {
+    canonicalType: "lean_body_mass",
+    sampleCount: 4,
+    dayCount: 4,
+    latestDate: dateKey(-1),
+  },
+  {
+    canonicalType: "vo2max",
+    sampleCount: 2,
+    dayCount: 2,
+    latestDate: dateKey(-2),
+  },
 ];
 
 const demoDiagnostics: HealthConnectReadDiagnostic[] = [
   {
-    recordType: 'SleepSession',
-    canonicalType: 'sleep_session',
-    permission: 'granted',
-    readKind: 'records',
+    recordType: "SleepSession",
+    canonicalType: "sleep_session",
+    permission: "granted",
+    readKind: "records",
     recordsRead: 14,
     samplesWritten: 14,
   },
   {
-    recordType: 'HeartRate',
-    canonicalType: 'heart_rate',
-    permission: 'granted',
-    readKind: 'records',
+    recordType: "HeartRate",
+    canonicalType: "heart_rate",
+    permission: "granted",
+    readKind: "records",
     recordsRead: 96,
     samplesWritten: 96,
   },
   {
-    recordType: 'RestingHeartRate',
-    canonicalType: 'resting_heart_rate',
-    permission: 'granted',
-    readKind: 'records',
+    recordType: "RestingHeartRate",
+    canonicalType: "resting_heart_rate",
+    permission: "granted",
+    readKind: "records",
     recordsRead: 14,
     samplesWritten: 14,
   },
   {
-    recordType: 'HeartRateVariabilityRmssd',
-    canonicalType: 'hrv_rmssd',
-    permission: 'granted',
-    readKind: 'records',
+    recordType: "HeartRateVariabilityRmssd",
+    canonicalType: "hrv_rmssd",
+    permission: "granted",
+    readKind: "records",
     recordsRead: 14,
     samplesWritten: 14,
   },
@@ -200,22 +237,24 @@ const demoDiagnostics: HealthConnectReadDiagnostic[] = [
 
 const demoSourceFreshness: SourceFreshness[] = [
   {
-    domain: 'sleep',
-    label: 'Sleep',
-    state: 'fresh',
-    canonicalTypes: ['sleep_session'],
+    domain: "sleep",
+    label: "Sleep",
+    state: "fresh",
+    canonicalTypes: ["sleep_session"],
     sampleCount: 14,
     dayCount: 14,
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T06:45:00.000Z`,
     ageDays: 0,
-    limitations: ['Demo HRV is RMSSD; SDNN from Apple Health would use its own baseline.'],
+    limitations: [
+      "Demo HRV is RMSSD; SDNN from Apple Health would use its own baseline.",
+    ],
   },
   {
-    domain: 'workouts',
-    label: 'Workouts',
-    state: 'fresh',
-    canonicalTypes: ['workout'],
+    domain: "workouts",
+    label: "Workouts",
+    state: "fresh",
+    canonicalTypes: ["workout"],
     sampleCount: 9,
     dayCount: 7,
     latestLocalDate: dateKey(-1),
@@ -224,34 +263,38 @@ const demoSourceFreshness: SourceFreshness[] = [
     limitations: [],
   },
   {
-    domain: 'steps',
-    label: 'Steps',
-    state: 'partial',
-    canonicalTypes: ['steps'],
+    domain: "steps",
+    label: "Steps",
+    state: "partial",
+    canonicalTypes: ["steps"],
     sampleCount: 14,
     dayCount: 14,
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T10:15:00.000Z`,
     ageDays: 0,
-    limitations: ['Today is still in progress; this domain may change after the next sync.'],
+    limitations: [
+      "Today is still in progress; this domain may change after the next sync.",
+    ],
   },
   {
-    domain: 'energy',
-    label: 'Energy',
-    state: 'partial',
-    canonicalTypes: ['active_energy', 'total_energy'],
+    domain: "energy",
+    label: "Energy",
+    state: "partial",
+    canonicalTypes: ["active_energy", "total_energy"],
     sampleCount: 28,
     dayCount: 14,
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T10:15:00.000Z`,
     ageDays: 0,
-    limitations: ['Today is still in progress; this domain may change after the next sync.'],
+    limitations: [
+      "Today is still in progress; this domain may change after the next sync.",
+    ],
   },
   {
-    domain: 'hrv',
-    label: 'HRV',
-    state: 'fresh',
-    canonicalTypes: ['hrv_rmssd', 'hrv_sdnn'],
+    domain: "hrv",
+    label: "HRV",
+    state: "fresh",
+    canonicalTypes: ["hrv_rmssd", "hrv_sdnn"],
     sampleCount: 14,
     dayCount: 14,
     latestLocalDate: latestDate,
@@ -260,10 +303,10 @@ const demoSourceFreshness: SourceFreshness[] = [
     limitations: [],
   },
   {
-    domain: 'resting_hr',
-    label: 'Resting HR',
-    state: 'fresh',
-    canonicalTypes: ['resting_heart_rate'],
+    domain: "resting_hr",
+    label: "Resting HR",
+    state: "fresh",
+    canonicalTypes: ["resting_heart_rate"],
     sampleCount: 14,
     dayCount: 14,
     latestLocalDate: latestDate,
@@ -272,34 +315,38 @@ const demoSourceFreshness: SourceFreshness[] = [
     limitations: [],
   },
   {
-    domain: 'nutrition',
-    label: 'Nutrition',
-    state: 'partial',
-    canonicalTypes: ['nutrition'],
+    domain: "nutrition",
+    label: "Nutrition",
+    state: "partial",
+    canonicalTypes: ["nutrition"],
     sampleCount: 8,
     dayCount: 8,
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T09:00:00.000Z`,
     ageDays: 0,
-    limitations: ['Today is still in progress; this domain may change after the next sync.'],
+    limitations: [
+      "Today is still in progress; this domain may change after the next sync.",
+    ],
   },
   {
-    domain: 'hydration',
-    label: 'Hydration',
-    state: 'partial',
-    canonicalTypes: ['hydration'],
+    domain: "hydration",
+    label: "Hydration",
+    state: "partial",
+    canonicalTypes: ["hydration"],
     sampleCount: 8,
     dayCount: 8,
     latestLocalDate: latestDate,
     lastUpdatedAt: `${latestDate}T09:30:00.000Z`,
     ageDays: 0,
-    limitations: ['Today is still in progress; this domain may change after the next sync.'],
+    limitations: [
+      "Today is still in progress; this domain may change after the next sync.",
+    ],
   },
   {
-    domain: 'body_composition',
-    label: 'Body composition',
-    state: 'fresh',
-    canonicalTypes: ['weight', 'body_fat', 'lean_body_mass'],
+    domain: "body_composition",
+    label: "Body composition",
+    state: "fresh",
+    canonicalTypes: ["weight", "body_fat", "lean_body_mass"],
     sampleCount: 12,
     dayCount: 4,
     latestLocalDate: dateKey(-1),
@@ -308,13 +355,13 @@ const demoSourceFreshness: SourceFreshness[] = [
     limitations: [],
   },
   {
-    domain: 'check_ins',
-    label: 'Check-ins',
-    state: 'missing',
+    domain: "check_ins",
+    label: "Check-ins",
+    state: "missing",
     canonicalTypes: [],
     sampleCount: 0,
     dayCount: 0,
-    limitations: ['Daily check-ins are not implemented in local storage yet.'],
+    limitations: ["Daily check-ins are not implemented in local storage yet."],
   },
 ];
 
@@ -331,70 +378,75 @@ const demoSnapshot: PipelineSnapshot = {
   history,
   recentWorkouts: [
     {
-      workoutId: 'demo-run-1',
-      platform: 'healthkit',
-      sourceApp: 'Apple Watch',
+      workoutId: "demo-run-1",
+      platform: "healthkit",
+      sourceApp: "Apple Watch",
       startAt: `${dateKey(-1)}T07:10:00.000Z`,
       endAt: `${dateKey(-1)}T07:52:00.000Z`,
       localDate: dateKey(-1),
-      name: 'Easy Run',
-      activityType: 'Running',
-      sportBucket: 'run',
+      name: "Easy Run",
+      activityType: "Running",
+      sportBucket: "run",
       elapsedSeconds: 2520,
       distanceKm: 6.4,
       activeKcal: 438,
       avgHrBpm: 142,
       maxHrBpm: 166,
       routeAvailable: true,
-      rawJson: '{}',
+      rawJson: "{}",
     },
     {
-      workoutId: 'demo-strength-1',
-      platform: 'healthkit',
-      sourceApp: 'Strength Log',
+      workoutId: "demo-strength-1",
+      platform: "healthkit",
+      sourceApp: "Strength Log",
       startAt: `${dateKey(-3)}T18:20:00.000Z`,
       endAt: `${dateKey(-3)}T19:02:00.000Z`,
       localDate: dateKey(-3),
-      name: 'Lower Strength',
-      activityType: 'Traditional Strength Training',
-      sportBucket: 'strength',
+      name: "Lower Strength",
+      activityType: "Traditional Strength Training",
+      sportBucket: "strength",
       elapsedSeconds: 2520,
       activeKcal: 220,
-      rawJson: '{}',
+      rawJson: "{}",
     },
   ],
   recentSamples: [],
   trainingLoad: buildTrainingLoadSnapshot(),
   recommendation: {
     readiness: 78,
-    readinessLabel: 'Primed',
-    color: 'positive',
-    title: 'Aerobic base',
-    detail: '40 min easy run, stay conversational',
+    readinessLabel: "Primed",
+    color: "positive",
+    title: "Aerobic base",
+    detail: "40 min easy run, stay conversational",
     reason:
-      'Sleep is solid, RMSSD HRV is above its matching baseline, and training load is unavailable, so this uses workout history conservatively.',
-    opener: 'Morning. Your wearable data already shows a strong recovery profile today.',
+      "Sleep is solid, RMSSD HRV is above its matching baseline, and training load is unavailable, so this uses workout history conservatively.",
+    opener:
+      "Morning. Your wearable data already shows a strong recovery profile today.",
     strain: 9.5,
-    strainTarget: '8-11',
+    strainTarget: "8-11",
   },
 };
 
 let lastSync: SyncRunRow | null = {
   id: 1,
-  provider: 'healthkit',
-  sync_type: 'manual',
+  provider: "healthkit",
+  sync_type: "manual",
   started_at: new Date(Date.now() - 38 * 60 * 1000).toISOString(),
   ended_at: new Date(Date.now() - 37 * 60 * 1000).toISOString(),
   range_start: dateKey(-7),
   range_end: dateKey(0),
   sample_count: demoSnapshot.totalSamples,
-  health_sample_count: demoSnapshot.totalSamples - demoSnapshot.workoutCount - demoSnapshot.sleepCount - demoSnapshot.nutritionDays,
+  health_sample_count:
+    demoSnapshot.totalSamples -
+    demoSnapshot.workoutCount -
+    demoSnapshot.sleepCount -
+    demoSnapshot.nutritionDays,
   workout_count: demoSnapshot.workoutCount,
   sleep_session_count: demoSnapshot.sleepCount,
   nutrition_day_count: demoSnapshot.nutritionDays,
   warning_count: 0,
   diagnostic_count: demoDiagnostics.length,
-  status: 'ok',
+  status: "ok",
   error: null,
 };
 
@@ -402,17 +454,18 @@ let syncRuns: SyncRunRow[] = lastSync ? [lastSync] : [];
 let demoCleared = false;
 
 let goalProfile: GoalProfile | null = normalizeGoalProfile({
-  primaryGoal: 'endurance',
-  secondaryGoals: ['strength'],
-  motivation: 'Build toward a confident half marathon block without overreaching.',
-  timeframe: '12 weeks',
-  experienceLevel: 'recreational',
-  preferredActivities: ['run', 'strength', 'walk'],
+  primaryGoal: "endurance",
+  secondaryGoals: ["strength"],
+  motivation:
+    "Build toward a confident half marathon block without overreaching.",
+  timeframe: "12 weeks",
+  experienceLevel: "recreational",
+  preferredActivities: ["run", "strength", "walk"],
   dislikedActivities: [],
-  constraints: ['protect recovery', 'avoid sudden volume jumps'],
+  constraints: ["protect recovery", "avoid sudden volume jumps"],
   riskFlags: [],
-  coachingStyle: 'supportive',
-  startingStrategy: 'conservative_build',
+  coachingStyle: "supportive",
+  startingStrategy: "conservative_build",
   confidence: 0.74,
 });
 
@@ -422,7 +475,9 @@ export async function getGoalProfile(): Promise<GoalProfile | null> {
   return goalProfile;
 }
 
-export async function saveGoalProfile(draft: GoalProfileDraft): Promise<GoalProfile> {
+export async function saveGoalProfile(
+  draft: GoalProfileDraft,
+): Promise<GoalProfile> {
   goalProfile = normalizeGoalProfile({
     ...(goalProfile ?? {}),
     ...draft,
@@ -456,7 +511,7 @@ export async function recordSyncRun(
   lastSync = {
     id: Date.now(),
     provider,
-    sync_type: details.syncType ?? 'manual',
+    sync_type: details.syncType ?? "manual",
     started_at: startedAt,
     ended_at: new Date().toISOString(),
     range_start: range.startDate.toISOString(),
@@ -468,8 +523,9 @@ export async function recordSyncRun(
     nutrition_day_count: details.nutritionDayCount ?? 0,
     warning_count: details.warningCount ?? 0,
     diagnostic_count: details.diagnosticCount ?? 0,
-    status: error ? 'error' : 'ok',
-    error: error instanceof Error ? error.message : error ? String(error) : null,
+    status: error ? "error" : "ok",
+    error:
+      error instanceof Error ? error.message : error ? String(error) : null,
   };
   syncRuns = [lastSync, ...syncRuns].slice(0, 12);
 }
@@ -478,7 +534,11 @@ export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {
   return demoCleared ? emptySnapshot : demoSnapshot;
 }
 
-function demoTableCount(total: number, firstDate: string | null, latestDate: string | null) {
+function demoTableCount(
+  total: number,
+  firstDate: string | null,
+  latestDate: string | null,
+) {
   return {
     total,
     first_date: firstDate,
@@ -486,7 +546,9 @@ function demoTableCount(total: number, firstDate: string | null, latestDate: str
   };
 }
 
-export async function getCoachHealthContext(_options: { rebuildDaily?: boolean } = {}) {
+export async function getCoachHealthContext(
+  _options: { rebuildDaily?: boolean } = {},
+) {
   if (demoCleared) {
     return {
       generatedAt: new Date().toISOString(),
@@ -512,7 +574,7 @@ export async function getCoachHealthContext(_options: { rebuildDaily?: boolean }
       recentDailyMetrics: [],
       recentWorkouts: [],
       coachDataInstruction:
-        'The web demo dataset was cleared. Treat health data as unavailable until a new demo or native sync is connected.',
+        "The web demo dataset was cleared. Treat health data as unavailable until a new demo or native sync is connected.",
     };
   }
 
@@ -539,10 +601,26 @@ export async function getCoachHealthContext(_options: { rebuildDaily?: boolean }
     generatedAt: new Date().toISOString(),
     hasSyncedHealthData: true,
     sqliteTables: {
-      healthSamples: demoTableCount(demoSnapshot.totalSamples, firstDate, latestDate),
-      sleepSessions: demoTableCount(demoSnapshot.sleepCount, firstDate, latestDate),
-      workouts: demoTableCount(demoSnapshot.workoutCount, dateKey(-12), dateKey(-1)),
-      nutritionDaily: demoTableCount(demoSnapshot.nutritionDays, dateKey(-12), latestDate),
+      healthSamples: demoTableCount(
+        demoSnapshot.totalSamples,
+        firstDate,
+        latestDate,
+      ),
+      sleepSessions: demoTableCount(
+        demoSnapshot.sleepCount,
+        firstDate,
+        latestDate,
+      ),
+      workouts: demoTableCount(
+        demoSnapshot.workoutCount,
+        dateKey(-12),
+        dateKey(-1),
+      ),
+      nutritionDaily: demoTableCount(
+        demoSnapshot.nutritionDays,
+        dateKey(-12),
+        latestDate,
+      ),
       dailyMetrics: demoTableCount(history.length, firstDate, latestDate),
       syncRuns,
     },
@@ -550,32 +628,32 @@ export async function getCoachHealthContext(_options: { rebuildDaily?: boolean }
     sourceFreshness: demoSourceFreshness,
     latestSamplesByType: [
       {
-        canonicalType: 'hrv_rmssd' as CanonicalType,
-        recordType: 'HeartRateVariabilityRmssd',
-        sourceApp: 'Apple Watch',
+        canonicalType: "hrv_rmssd" as CanonicalType,
+        recordType: "HeartRateVariabilityRmssd",
+        sourceApp: "Apple Watch",
         localDate: latestDate,
         startAt: `${latestDate}T06:45:00.000Z`,
         value: history[0].hrvLastNightAvg,
-        unit: 'ms',
-        hrvMethod: 'rmssd' as const,
+        unit: "ms",
+        hrvMethod: "rmssd" as const,
       },
       {
-        canonicalType: 'resting_heart_rate' as CanonicalType,
-        recordType: 'RestingHeartRate',
-        sourceApp: 'Apple Watch',
+        canonicalType: "resting_heart_rate" as CanonicalType,
+        recordType: "RestingHeartRate",
+        sourceApp: "Apple Watch",
         localDate: latestDate,
         startAt: `${latestDate}T06:45:00.000Z`,
         value: history[0].restingHr,
-        unit: 'bpm',
+        unit: "bpm",
       },
       {
-        canonicalType: 'steps' as CanonicalType,
-        recordType: 'Steps',
-        sourceApp: 'Apple Watch',
+        canonicalType: "steps" as CanonicalType,
+        recordType: "Steps",
+        sourceApp: "Apple Watch",
         localDate: latestDate,
         startAt: `${latestDate}T23:59:00.000Z`,
         value: history[0].steps,
-        unit: 'count',
+        unit: "count",
       },
     ],
     recentDailyMetrics: demoSnapshot.history.slice(0, 7),
@@ -591,7 +669,7 @@ export async function getCoachHealthContext(_options: { rebuildDaily?: boolean }
       sourceApp: workout.sourceApp,
     })),
     coachDataInstruction:
-      'Expo web is using local mock SQLite-style demo data. Treat it as synced demo health data, not live device records.',
+      "Expo web is using local mock SQLite-style demo data. Treat it as synced demo health data, not live device records.",
   };
 }
 
@@ -600,7 +678,7 @@ export async function getLastSyncRun(): Promise<SyncRunRow | null> {
 }
 
 export async function getLastSuccessfulSyncRun(): Promise<SyncRunRow | null> {
-  return syncRuns.find((run) => run.status === 'ok') ?? null;
+  return syncRuns.find((run) => run.status === "ok") ?? null;
 }
 
 export async function getRecentSyncRuns(limit = 6): Promise<SyncRunRow[]> {
@@ -621,6 +699,16 @@ export async function clearPipeline(): Promise<void> {
   syncRuns = [];
 }
 
+export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
+  const artifacts = buildPipelineExportArtifacts(demoSnapshot);
+
+  return {
+    jsonFileUri: `web-demo://${artifacts.jsonFileName}`,
+    healthCheckFileUri: `web-demo://${artifacts.healthCheckFileName}`,
+  };
+}
+
 export async function exportPipelineJson(): Promise<string> {
-  return 'web-demo://biostream-pipeline.json';
+  const result = await exportPipelineArtifacts();
+  return result.jsonFileUri;
 }


### PR DESCRIPTION
## Summary
- add deterministic health_check.md generation from pipeline snapshots
- export timestamped JSON and Markdown artifacts together
- stack on #18 so health_check fixtures and payload include trainingLoad

## Verification
- npm test -- --runInBand src/export/healthCheck.test.ts src/export/pipelineExport.test.ts
- npm run typecheck
- git diff --check codex/issue-18-training-load..HEAD

Fixes #20