### PR TITLE
Track B training load placeholder boundary

### DIFF
--- a/src/coach/trainingLoad.test.ts
+++ b/src/coach/trainingLoad.test.ts
@@ -1,0 +1,125 @@
+import {
+  buildTrainingLoadSnapshot,
+  recommendationBoundaryForTrainingLoad,
+  toTrainingLoadExport,
+} from "./trainingLoad";
+
+describe("training load boundary", () => {
+  it("marks training load unavailable instead of deriving it from generic workout history", () => {
+    const snapshot = buildTrainingLoadSnapshot({
+      genericPlatformWorkoutCount: 8,
+    });
+    const boundary = recommendationBoundaryForTrainingLoad(snapshot);
+    const exported = toTrainingLoadExport(snapshot);
+
+    expect(snapshot.trainingLoadStatus).toBe("unavailable");
+    expect(snapshot.intervals).toBeUndefined();
+    expect(boundary.canUseTrainingLoad).toBe(false);
+    expect(boundary.intensityAdjustment).toBe("none");
+    expect(boundary.sourcesIgnored).toContain("training load unavailable");
+    expect(exported.training_load_status).toBe("unavailable");
+    expect(exported.intervals).toBeNull();
+  });
+
+  it("preserves source-provided Intervals-ready fields without calculating a model", () => {
+    const snapshot = buildTrainingLoadSnapshot({
+      source: {
+        trainingLoadStatus: "source-provided",
+        sourceKind: "intervals_icu",
+        sourceName: "Intervals.icu",
+        method: "external_source",
+        asOf: "2026-04-28T08:00:00.000Z",
+        intervals: {
+          ctl: 42,
+          atl: 51,
+          tsb: -9,
+          rampRate7d: 2.5,
+          dailyLoad: 86,
+          dailyLoadUnit: "intervals_icu_load",
+        },
+      },
+    });
+    const boundary = recommendationBoundaryForTrainingLoad(snapshot);
+    const exported = toTrainingLoadExport(snapshot);
+
+    expect(snapshot.trainingLoadStatus).toBe("source-provided");
+    expect(snapshot.intervals).toEqual({
+      ctl: 42,
+      atl: 51,
+      tsb: -9,
+      rampRate7d: 2.5,
+      dailyLoad: 86,
+      dailyLoadUnit: "intervals_icu_load",
+    });
+    expect(boundary.canUseTrainingLoad).toBe(true);
+    expect(boundary.intensityAdjustment).toBe("none");
+    expect(exported.training_load_status).toBe("source-provided");
+    expect(exported.intervals?.ctl).toBe(42);
+  });
+
+  it("allows derived load only when a documented method is supplied", () => {
+    const snapshot = buildTrainingLoadSnapshot({
+      source: {
+        trainingLoadStatus: "derived",
+        sourceKind: "documented_local_model",
+        sourceName: "Local load model",
+        method: "documented_trimp_v1",
+        asOf: "2026-04-28T08:00:00.000Z",
+        intervals: {
+          dailyLoad: 54,
+          dailyLoadUnit: "trimp",
+        },
+      },
+    });
+    const boundary = recommendationBoundaryForTrainingLoad(snapshot);
+    const exported = toTrainingLoadExport(snapshot);
+
+    expect(snapshot.trainingLoadStatus).toBe("derived");
+    expect(boundary.canUseTrainingLoad).toBe(true);
+    expect(exported.method).toBe("documented_trimp_v1");
+    expect(exported.intervals?.dailyLoadUnit).toBe("trimp");
+  });
+
+  it("downgrades derived load without a documented method to unavailable", () => {
+    const snapshot = buildTrainingLoadSnapshot({
+      source: {
+        trainingLoadStatus: "derived",
+        sourceKind: "documented_local_model",
+        sourceName: "Local load model",
+      },
+    });
+    const boundary = recommendationBoundaryForTrainingLoad(snapshot);
+    const exported = toTrainingLoadExport(snapshot);
+
+    expect(snapshot.trainingLoadStatus).toBe("unavailable");
+    expect(boundary.canUseTrainingLoad).toBe(false);
+    expect(exported.training_load_status).toBe("unavailable");
+    expect(exported.limitations.join(" ")).toMatch(/method name/i);
+  });
+
+  it("preserves stale load for export but ignores it for recommendations", () => {
+    const snapshot = buildTrainingLoadSnapshot({
+      source: {
+        trainingLoadStatus: "stale",
+        sourceKind: "intervals_icu",
+        sourceName: "Intervals.icu",
+        method: "external_source",
+        asOf: "2026-04-20T08:00:00.000Z",
+        staleAfterDays: 3,
+        intervals: {
+          ctl: 38,
+          atl: 42,
+          tsb: -4,
+        },
+      },
+    });
+    const boundary = recommendationBoundaryForTrainingLoad(snapshot);
+    const exported = toTrainingLoadExport(snapshot);
+
+    expect(snapshot.trainingLoadStatus).toBe("stale");
+    expect(boundary.canUseTrainingLoad).toBe(false);
+    expect(boundary.sourcesIgnored).toContain("stale training load");
+    expect(exported.training_load_status).toBe("stale");
+    expect(exported.intervals?.ctl).toBe(38);
+  });
+});

--- a/src/coach/trainingLoad.ts
+++ b/src/coach/trainingLoad.ts
@@ -1,0 +1,172 @@
+import type {
+  TrainingLoadIntervalsFields,
+  TrainingLoadSnapshot,
+  TrainingLoadSourceKind,
+  TrainingLoadStatus,
+} from "../health/types";
+
+type SuppliedTrainingLoadStatus = Exclude<TrainingLoadStatus, "unavailable">;
+
+export type TrainingLoadSourceInput = {
+  trainingLoadStatus: SuppliedTrainingLoadStatus;
+  sourceKind: TrainingLoadSourceKind;
+  sourceName: string;
+  method?: string;
+  asOf?: string;
+  staleAfterDays?: number;
+  intervals?: TrainingLoadIntervalsFields;
+};
+
+export type BuildTrainingLoadSnapshotInput = {
+  source?: TrainingLoadSourceInput | null;
+  genericPlatformWorkoutCount?: number;
+};
+
+export type TrainingLoadRecommendationBoundary = {
+  canUseTrainingLoad: boolean;
+  intensityAdjustment: "none";
+  sourcesUsed: string[];
+  sourcesIgnored: string[];
+  recommendationNote: string;
+};
+
+export type TrainingLoadExport = {
+  training_load_status: TrainingLoadStatus;
+  label: string;
+  summary: string;
+  source_kind: TrainingLoadSourceKind | null;
+  source_name: string | null;
+  method: string | null;
+  as_of: string | null;
+  stale_after_days: number | null;
+  intervals: TrainingLoadIntervalsFields | null;
+  limitations: string[];
+};
+
+const unavailableLimitations = [
+  "Health Connect and Apple Health workouts are preserved as raw activity history, not converted into CTL, ATL, TSB, or daily training load.",
+  "Connect an external load source or add a documented local model before using training load in recommendations.",
+];
+
+export function buildTrainingLoadSnapshot(
+  input: BuildTrainingLoadSnapshotInput = {},
+): TrainingLoadSnapshot {
+  if (!input.source) {
+    return {
+      trainingLoadStatus: "unavailable",
+      label: "Training load unavailable",
+      summary:
+        "Training load is not available from the current platform data. Workouts stay available for history, but load is not estimated from generic activity records.",
+      limitations: [...unavailableLimitations],
+    };
+  }
+
+  const source = input.source;
+
+  if (source.trainingLoadStatus === "derived" && !source.method) {
+    return {
+      trainingLoadStatus: "unavailable",
+      label: "Training load unavailable",
+      summary:
+        "A derived training load source was provided without a documented method, so it is ignored.",
+      sourceKind: source.sourceKind,
+      sourceName: source.sourceName,
+      limitations: [
+        "Derived training load must include a method name before it can influence recommendations.",
+        ...unavailableLimitations,
+      ],
+    };
+  }
+
+  if (source.trainingLoadStatus === "stale") {
+    return {
+      trainingLoadStatus: "stale",
+      label: "Training load stale",
+      summary:
+        "A training load source exists, but it is stale and should be shown only as unavailable for today.",
+      sourceKind: source.sourceKind,
+      sourceName: source.sourceName,
+      method: source.method,
+      asOf: source.asOf,
+      staleAfterDays: source.staleAfterDays,
+      intervals: source.intervals,
+      limitations: [
+        "Stale training load is preserved for export and ignored by recommendation logic.",
+      ],
+    };
+  }
+
+  return {
+    trainingLoadStatus: source.trainingLoadStatus,
+    label:
+      source.trainingLoadStatus === "source-provided"
+        ? "Training load source-provided"
+        : "Training load derived",
+    summary:
+      source.trainingLoadStatus === "source-provided"
+        ? "Training load was supplied by an explicit source and can cross the recommendation boundary."
+        : "Training load was produced by a documented local method and can cross the recommendation boundary.",
+    sourceKind: source.sourceKind,
+    sourceName: source.sourceName,
+    method: source.method,
+    asOf: source.asOf,
+    staleAfterDays: source.staleAfterDays,
+    intervals: source.intervals,
+    limitations: [
+      "This boundary preserves load fields but does not calculate a training stress model.",
+    ],
+  };
+}
+
+export function recommendationBoundaryForTrainingLoad(
+  snapshot: TrainingLoadSnapshot,
+): TrainingLoadRecommendationBoundary {
+  if (
+    snapshot.trainingLoadStatus === "source-provided" ||
+    snapshot.trainingLoadStatus === "derived"
+  ) {
+    const source = snapshot.sourceName ?? "training load source";
+
+    return {
+      canUseTrainingLoad: true,
+      intensityAdjustment: "none",
+      sourcesUsed: [`training load from ${source}`],
+      sourcesIgnored: [],
+      recommendationNote:
+        "Training load is available at the boundary, but this placeholder does not calculate intensity changes from it.",
+    };
+  }
+
+  const ignored =
+    snapshot.trainingLoadStatus === "stale"
+      ? "stale training load"
+      : "training load unavailable";
+
+  return {
+    canUseTrainingLoad: false,
+    intensityAdjustment: "none",
+    sourcesUsed: [],
+    sourcesIgnored: [ignored],
+    recommendationNote:
+      snapshot.trainingLoadStatus === "stale"
+        ? "Stale training load was ignored instead of being used to raise intensity."
+        : "Training load was unavailable, so no load score was estimated from generic workouts.",
+  };
+}
+
+export function toTrainingLoadExport(
+  snapshot: TrainingLoadSnapshot,
+): TrainingLoadExport {
+  return {
+    training_load_status: snapshot.trainingLoadStatus,
+    label: snapshot.label,
+    summary: snapshot.summary,
+    source_kind: snapshot.sourceKind ?? null,
+    source_name: snapshot.sourceName ?? null,
+    method: snapshot.method ?? null,
+    as_of: snapshot.asOf ?? null,
+    stale_after_days: snapshot.staleAfterDays ?? null,
+    intervals: snapshot.intervals ?? null,
+    limitations: snapshot.limitations,
+  };
+}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -8,6 +8,7 @@ import {
   Zap,
 } from 'lucide-react-native';
 
+import { buildTrainingLoadSnapshot } from '../coach/trainingLoad';
 import type { PipelineSnapshot } from '../health/types';
 import type { AppSettings } from '../storage/appSettings';
 import type { AnalyticsMetricConfig } from './types';
@@ -34,6 +35,7 @@ export const emptySnapshot: PipelineSnapshot = {
   history: [],
   recentWorkouts: [],
   recentSamples: [],
+  trainingLoad: buildTrainingLoadSnapshot(),
   recommendation: {
     readiness: null,
     readinessLabel: 'Connect',

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -256,6 +256,34 @@ export type DailyMetrics = {
   generatedAt: string;
 };
 
+export type TrainingLoadStatus = 'unavailable' | 'source-provided' | 'derived' | 'stale';
+
+export type TrainingLoadSourceKind = 'intervals_icu' | 'documented_local_model' | 'vendor';
+
+export type TrainingLoadDailyLoadUnit = 'intervals_icu_load' | 'tss' | 'trimp' | 'unknown';
+
+export type TrainingLoadIntervalsFields = {
+  ctl?: number;
+  atl?: number;
+  tsb?: number;
+  rampRate7d?: number;
+  dailyLoad?: number;
+  dailyLoadUnit?: TrainingLoadDailyLoadUnit;
+};
+
+export type TrainingLoadSnapshot = {
+  trainingLoadStatus: TrainingLoadStatus;
+  label: string;
+  summary: string;
+  sourceKind?: TrainingLoadSourceKind;
+  sourceName?: string;
+  method?: string;
+  asOf?: string;
+  staleAfterDays?: number;
+  intervals?: TrainingLoadIntervalsFields;
+  limitations: string[];
+};
+
 export type CoachTone = 'positive' | 'warm' | 'cool' | 'neutral';
 
 export type CoachRecommendation = {
@@ -290,5 +318,6 @@ export type PipelineSnapshot = {
   history: DailyMetrics[];
   recentWorkouts: WorkoutRecord[];
   recentSamples: HealthSample[];
+  trainingLoad: TrainingLoadSnapshot;
   recommendation: CoachRecommendation;
 };

--- a/src/screens/SourceScreen.tsx
+++ b/src/screens/SourceScreen.tsx
@@ -557,6 +557,7 @@ export function SourceScreen({
         <View style={styles.privacyCard}>
           <Lock color={tokens.muted} size={16} strokeWidth={2} />
           <Text style={styles.privacyText}>
+            {snapshot.trainingLoad.summary}{' '}
             Vendor-only metrics such as stress, body battery, sleep score, and
             training load are preserved only when a source writes them. They are not
             fabricated from generic platform data.

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -4,6 +4,11 @@ import * as SQLite from "expo-sqlite";
 
 import { extractRiskFlagsFromCoachRequest } from "../coach/riskFlags";
 import {
+  buildTrainingLoadSnapshot,
+  recommendationBoundaryForTrainingLoad,
+  toTrainingLoadExport,
+} from "../coach/trainingLoad";
+import {
   normalizeGoalProfile,
   type CoachingStyle,
   type ExperienceLevel,
@@ -37,6 +42,7 @@ import type {
   SleepSessionRecord,
   SourceFreshness,
   SourceFreshnessDomain,
+  TrainingLoadSnapshot,
   SportBucket,
   SyncPayload,
   SyncRange,
@@ -2547,10 +2553,17 @@ function sourceFreshnessPenalty(gaps: SourceFreshness[]): number {
   return gaps.length ? 3 : 0;
 }
 
+function buildCurrentTrainingLoadSnapshot(
+  genericPlatformWorkoutCount = 0,
+): TrainingLoadSnapshot {
+  return buildTrainingLoadSnapshot({ genericPlatformWorkoutCount });
+}
+
 function deriveRecommendation(
   current: DailyMetrics | null,
   history: DailyMetrics[],
   sourceFreshness: SourceFreshness[] = [],
+  trainingLoad: TrainingLoadSnapshot = buildCurrentTrainingLoadSnapshot(),
 ): CoachRecommendation {
   if (!current || current.sourceCount === 0) {
     return {
@@ -2588,6 +2601,7 @@ function deriveRecommendation(
   let readiness = 56;
   const signals: string[] = [];
   const freshnessGaps = recommendationFreshnessGaps(sourceFreshness);
+  const trainingLoadBoundary = recommendationBoundaryForTrainingLoad(trainingLoad);
 
   if (current.sleepSeconds != null) {
     if (sleepHours >= 7.5) {
@@ -2656,6 +2670,10 @@ function deriveRecommendation(
     );
     readiness -= sourceFreshnessPenalty(freshnessGaps);
     signals.push(`${labels.join(" and ")}, so this call is conservative`);
+  }
+
+  if (!trainingLoadBoundary.canUseTrainingLoad) {
+    signals.push(trainingLoadBoundary.recommendationNote);
   }
 
   readiness = Math.max(20, Math.min(96, Math.round(readiness)));
@@ -2760,6 +2778,7 @@ export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {
       history.find((row) => row.date === todayKey) ?? history[0] ?? null;
     const recentWorkouts = await getRecentWorkoutsFromDb(db, 5);
     const recentSamples = await getRecentSamplesFromDb(db, 12);
+    const trainingLoad = buildCurrentTrainingLoadSnapshot(dedupedWorkoutCount);
 
     return {
       totalSamples: Number(countRow?.total ?? 0),
@@ -2819,7 +2838,8 @@ export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {
         metadataJson: row.metadata_json,
         sourceModifiedAt: row.source_modified_at ?? undefined,
       })),
-      recommendation: deriveRecommendation(today, history, sourceFreshness),
+      trainingLoad,
+      recommendation: deriveRecommendation(today, history, sourceFreshness, trainingLoad),
     };
   });
 }
@@ -3109,6 +3129,9 @@ export async function exportPipelineJson(): Promise<string> {
       goal_profile: goalProfile ?? undefined,
     });
 
+    const trainingLoad = buildCurrentTrainingLoadSnapshot(
+      dedupeWorkoutRows(workouts).length,
+    );
     const payload = {
       schema: "biostream_training_pipeline.v5",
       exportedAt,
@@ -3122,6 +3145,7 @@ export async function exportPipelineJson(): Promise<string> {
       diagnostics,
       goalProfile,
       riskFlags,
+      trainingLoad: toTrainingLoadExport(trainingLoad),
     };
 
     const directory = FileSystem.documentDirectory;

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -10,6 +10,7 @@ import type {
   SyncRange,
 } from '../health/types';
 import { emptySnapshot } from '../core/constants';
+import { buildTrainingLoadSnapshot } from '../coach/trainingLoad';
 import {
   normalizeGoalProfile,
   type GoalProfile,
@@ -363,13 +364,15 @@ const demoSnapshot: PipelineSnapshot = {
     },
   ],
   recentSamples: [],
+  trainingLoad: buildTrainingLoadSnapshot(),
   recommendation: {
     readiness: 78,
     readinessLabel: 'Primed',
     color: 'positive',
     title: 'Aerobic base',
     detail: '40 min easy run, stay conversational',
-    reason: 'Sleep is solid, RMSSD HRV is above its matching baseline, and recent training load is consistent.',
+    reason:
+      'Sleep is solid, RMSSD HRV is above its matching baseline, and training load is unavailable, so this uses workout history conservatively.',
     opener: 'Morning. Your wearable data already shows a strong recovery profile today.',
     strain: 9.5,
     strainTarget: '8-11',


### PR DESCRIPTION
## Summary
- add explicit training load unavailable/source-provided/derived/stale boundary
- prevent generic workouts from being treated as training load
- include training load state in snapshots, recommendation reasoning, Source screen copy, and export JSON

## Verification
- npm test -- --runInBand src/coach/trainingLoad.test.ts
- npm run typecheck
- git diff --check origin/main..HEAD

Fixes #18