### PR TITLE
[codex] Add splash start flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Keyboard, KeyboardAvoidingView, Platform, SafeAreaView } from 'react-native';
 
 import { openAiCoachModel, sendCoachMessage } from './src/ai/openaiCoach';
@@ -11,6 +11,7 @@ import { CoachOnboardingScreen } from './src/screens/CoachOnboardingScreen';
 import { CoachScreen } from './src/screens/CoachScreen';
 import { HistoryScreen } from './src/screens/HistoryScreen';
 import { SourceScreen } from './src/screens/SourceScreen';
+import { SplashScreen, StartLoadingScreen } from './src/screens/SplashScreen';
 import { WorkoutPlanScreen } from './src/screens/WorkoutPlanScreen';
 import { currentHealthProviderId, currentHealthProviderLabel, syncCurrentPlatform } from './src/health/syncPipeline';
 import type { PipelineSnapshot, SyncRange } from './src/health/types';
@@ -39,11 +40,11 @@ import { styles } from './src/styles/appStyles';
 import { TabBar } from './src/ui/TabBar';
 
 export default function App() {
+  const [entryMode, setEntryMode] = useState<'splash' | 'onboarding' | 'loading-start' | 'app'>('splash');
   const [activeTab, setActiveTab] = useState<Tab>('coach');
   const [rangeDays, setRangeDays] = useState(baselineRangeDays);
   const [snapshot, setSnapshot] = useState<PipelineSnapshot>(emptySnapshot);
   const [goalText, setGoalText] = useState('');
-  const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(false);
   const [lastSync, setLastSync] = useState<LastSync>(null);
   const [lastSuccessfulSync, setLastSuccessfulSync] = useState<LastSync>(null);
   const [recentSyncRuns, setRecentSyncRuns] = useState<SyncRuns>([]);
@@ -58,9 +59,12 @@ export default function App() {
   const [status, setStatus] = useState('Ready');
   const [warnings, setWarnings] = useState<string[]>([]);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const [storeReady, setStoreReady] = useState(false);
+  const bootstrapPromiseRef = useRef<Promise<void> | null>(null);
 
   const range = useMemo(() => makeSyncRange(rangeDays), [rangeDays]);
   const canSync = Platform.OS === 'ios' || Platform.OS === 'android';
+  const sourceLabel = canSync ? currentHealthProviderLabel() : 'Apple Health / Health Connect';
 
   async function refreshStore() {
     const [nextSnapshot, nextLastSync, nextLastSuccessfulSync, nextRecentSyncRuns] = await Promise.all([
@@ -76,15 +80,25 @@ export default function App() {
   }
 
   useEffect(() => {
-    void initTrainingStore()
+    const bootstrap = initTrainingStore()
       .then(async () => {
         const nextSettings = await loadAppSettings();
         setAppSettings(nextSettings);
         setRangeDays(nextSettings.defaultSyncRangeDays);
         await refreshStore();
       })
-      .catch((error) => setStatus(String(error instanceof Error ? error.message : error)));
+      .catch((error) => setStatus(String(error instanceof Error ? error.message : error)))
+      .finally(() => setStoreReady(true));
+
+    bootstrapPromiseRef.current = bootstrap;
+    void bootstrap;
   }, []);
+
+  async function ensureStoreReady() {
+    if (bootstrapPromiseRef.current) {
+      await bootstrapPromiseRef.current;
+    }
+  }
 
   useEffect(() => {
     const showSubscription = Keyboard.addListener('keyboardDidShow', () => setKeyboardVisible(true));
@@ -252,6 +266,8 @@ export default function App() {
   }
 
   async function runSync(syncType: 'manual' | 'incremental' = 'manual') {
+    await ensureStoreReady();
+
     if (!canSync) {
       setStatus('Use an iOS or Android dev build.');
       return;
@@ -297,6 +313,16 @@ export default function App() {
     }
   }
 
+  async function syncDataAndStart() {
+    setActiveTab('coach');
+    setEntryMode('loading-start');
+    setStatus(canSync ? `Loading data from ${sourceLabel}` : 'Opening local health store');
+
+    await ensureStoreReady();
+    await runSync();
+    setEntryMode('app');
+  }
+
   async function runExport() {
     setBusy(true);
     try {
@@ -332,22 +358,34 @@ export default function App() {
         keyboardVerticalOffset={0}
         style={styles.appShell}
       >
-        {!hasCompletedOnboarding ? (
+        {entryMode === 'splash' ? (
+          <SplashScreen
+            busy={!storeReady}
+            onStartOnboarding={() => setEntryMode('onboarding')}
+            onSyncAndStart={() => void syncDataAndStart()}
+            sourceLabel={sourceLabel}
+            status={storeReady ? status : 'Opening local health store'}
+          />
+        ) : null}
+        {entryMode === 'onboarding' ? (
           <CoachOnboardingScreen
             busy={busy}
             canSync={canSync}
             onComplete={(nextGoal) => {
               setGoalText(nextGoal);
-              setHasCompletedOnboarding(true);
+              setEntryMode('app');
               setActiveTab('coach');
             }}
             onSync={runSync}
-            sourceLabel={canSync ? currentHealthProviderLabel() : 'Apple Health / Health Connect'}
+            sourceLabel={sourceLabel}
             status={status}
             snapshot={snapshot}
           />
         ) : null}
-        {hasCompletedOnboarding && activeTab === 'coach' ? (
+        {entryMode === 'loading-start' ? (
+          <StartLoadingScreen sourceLabel={sourceLabel} status={status} />
+        ) : null}
+        {entryMode === 'app' && activeTab === 'coach' ? (
           <CoachScreen
             busy={busy}
             coachBusy={coachBusy}
@@ -365,13 +403,13 @@ export default function App() {
             warnings={warnings}
           />
         ) : null}
-        {hasCompletedOnboarding && activeTab === 'workout' ? (
+        {entryMode === 'app' && activeTab === 'workout' ? (
           <WorkoutPlanScreen goalText={goalText} snapshot={snapshot} />
         ) : null}
-        {hasCompletedOnboarding && activeTab === 'history' ? (
+        {entryMode === 'app' && activeTab === 'history' ? (
           <HistoryScreen goalText={goalText} snapshot={snapshot} />
         ) : null}
-        {hasCompletedOnboarding && activeTab === 'you' ? (
+        {entryMode === 'app' && activeTab === 'you' ? (
           <SourceScreen
             apiKeyDraft={apiKeyDraft}
             appSettings={appSettings}
@@ -394,11 +432,8 @@ export default function App() {
             status={status}
           />
         ) : null}
-        {hasCompletedOnboarding && !keyboardVisible ? (
-          <TabBar
-            active={activeTab}
-            onChange={setActiveTab}
-          />
+        {!keyboardVisible && entryMode === 'app' ? (
+          <TabBar active={activeTab} onChange={setActiveTab} />
         ) : null}
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -1,0 +1,79 @@
+import { ActivityIndicator, Pressable, Text, View } from 'react-native';
+import { MessageCircle, RefreshCw } from 'lucide-react-native';
+
+import { styles } from '../styles/appStyles';
+import { tokens } from '../theme/tokens';
+import { CoachAvatar } from '../ui/primitives';
+
+export function SplashScreen({
+  busy,
+  onStartOnboarding,
+  onSyncAndStart,
+  sourceLabel,
+  status,
+}: {
+  busy: boolean;
+  onStartOnboarding: () => void;
+  onSyncAndStart: () => void;
+  sourceLabel: string;
+  status: string;
+}) {
+  return (
+    <View style={styles.splashScreen}>
+      <View style={styles.splashHeader}>
+        <CoachAvatar size={44} />
+        <Text style={styles.splashTitle}>BioStream</Text>
+        <Text style={styles.splashCopy}>Choose how you want to start.</Text>
+      </View>
+
+      <View style={styles.splashActions}>
+        <Pressable accessibilityRole="button" onPress={onStartOnboarding} style={({ pressed }) => [styles.splashOption, pressed && styles.pressed]}>
+          <View style={styles.splashOptionIcon}>
+            <MessageCircle color={tokens.ink} size={20} strokeWidth={2.2} />
+          </View>
+          <View style={styles.splashOptionCopy}>
+            <Text style={styles.splashOptionTitle}>Onboarding</Text>
+            <Text style={styles.splashOptionText}>Set goals, constraints, and data preferences first.</Text>
+          </View>
+        </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          disabled={busy}
+          onPress={onSyncAndStart}
+          style={({ pressed }) => [styles.splashOption, styles.splashOptionPrimary, busy && styles.disabled, pressed && !busy && styles.pressed]}
+        >
+          <View style={[styles.splashOptionIcon, styles.splashOptionIconPrimary]}>
+            {busy ? <ActivityIndicator color={tokens.surface} size="small" /> : <RefreshCw color={tokens.surface} size={20} strokeWidth={2.2} />}
+          </View>
+          <View style={styles.splashOptionCopy}>
+            <Text style={[styles.splashOptionTitle, styles.splashOptionTitlePrimary]}>Sync data & start</Text>
+            <Text style={[styles.splashOptionText, styles.splashOptionTextPrimary]}>{busy ? status : `Load data from ${sourceLabel} and open the coach.`}</Text>
+          </View>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export function StartLoadingScreen({ sourceLabel, status }: { sourceLabel: string; status: string }) {
+  return (
+    <View style={styles.screen}>
+      <View style={styles.topBar}>
+        <View style={styles.topBarLeft}>
+          <CoachAvatar size={32} />
+          <View>
+            <Text style={styles.topTitle}>Coach</Text>
+            <Text style={styles.topMeta}>Loading health data</Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.startLoadingContent}>
+        <ActivityIndicator color={tokens.ink} size="large" />
+        <Text style={styles.startLoadingTitle}>Loading</Text>
+        <Text style={styles.startLoadingText}>{status || `Getting recent data from ${sourceLabel}.`}</Text>
+      </View>
+    </View>
+  );
+}

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -2,7 +2,7 @@ import { Platform, StatusBar as NativeStatusBar, StyleSheet } from 'react-native
 
 import { tokens } from '../theme/tokens';
 
-const androidStatusBarInset = Platform.OS === 'android' ? NativeStatusBar.currentHeight ?? 0 : 0;
+const androidStatusBarInset = Platform.OS === 'android' ? (NativeStatusBar.currentHeight ?? 0) : 0;
 
 export const styles = StyleSheet.create({
   safeArea: {
@@ -17,6 +17,106 @@ export const styles = StyleSheet.create({
   screen: {
     flex: 1,
     backgroundColor: tokens.bg,
+  },
+  splashScreen: {
+    backgroundColor: tokens.bg,
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 22,
+  },
+  splashHeader: {
+    alignItems: 'flex-start',
+    gap: 10,
+    marginBottom: 28,
+  },
+  splashTitle: {
+    color: tokens.ink,
+    fontFamily: tokens.serif,
+    fontSize: 42,
+    fontWeight: '400',
+    letterSpacing: 0,
+    lineHeight: 47,
+  },
+  splashCopy: {
+    color: tokens.muted,
+    fontSize: 15,
+    letterSpacing: 0,
+    lineHeight: 22,
+  },
+  splashActions: {
+    gap: 12,
+  },
+  splashOption: {
+    alignItems: 'center',
+    backgroundColor: tokens.surface,
+    borderColor: tokens.line,
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 12,
+    minHeight: 88,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+  },
+  splashOptionPrimary: {
+    backgroundColor: tokens.ink,
+    borderColor: tokens.ink,
+  },
+  splashOptionIcon: {
+    alignItems: 'center',
+    backgroundColor: tokens.surfaceAlt,
+    borderRadius: 8,
+    height: 42,
+    justifyContent: 'center',
+    width: 42,
+  },
+  splashOptionIconPrimary: {
+    backgroundColor: tokens.inkSoft,
+  },
+  splashOptionCopy: {
+    flex: 1,
+    gap: 3,
+  },
+  splashOptionTitle: {
+    color: tokens.ink,
+    fontSize: 15,
+    fontWeight: '900',
+    letterSpacing: 0,
+  },
+  splashOptionTitlePrimary: {
+    color: tokens.surface,
+  },
+  splashOptionText: {
+    color: tokens.muted,
+    fontSize: 13,
+    letterSpacing: 0,
+    lineHeight: 18,
+  },
+  splashOptionTextPrimary: {
+    color: tokens.bgDeep,
+  },
+  startLoadingContent: {
+    alignItems: 'center',
+    flex: 1,
+    gap: 12,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  startLoadingTitle: {
+    color: tokens.ink,
+    fontFamily: tokens.serif,
+    fontSize: 32,
+    fontWeight: '400',
+    letterSpacing: 0,
+    lineHeight: 36,
+  },
+  startLoadingText: {
+    color: tokens.muted,
+    fontSize: 14,
+    letterSpacing: 0,
+    lineHeight: 20,
+    maxWidth: 280,
+    textAlign: 'center',
   },
   onboardingProgress: {
     backgroundColor: tokens.bgDeep,
@@ -153,16 +253,23 @@ export const styles = StyleSheet.create({
     flexShrink: 0,
     width: 32,
   },
+  coachBubble: {
+    backgroundColor: tokens.surface,
+    borderColor: tokens.lineSoft,
+    borderRadius: 18,
+    borderWidth: 1,
+    flexShrink: 1,
+    maxWidth: '100%',
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+  },
   coachText: {
     color: tokens.ink,
     flexShrink: 1,
-    fontFamily: tokens.serif,
-    fontSize: 18,
-    fontWeight: '400',
+    fontSize: 14,
+    fontWeight: '700',
     letterSpacing: 0,
-    lineHeight: 25,
-    paddingHorizontal: 2,
-    paddingVertical: 3,
+    lineHeight: 20,
   },
   userBubble: {
     alignSelf: 'flex-end',

--- a/src/test/appStructure.test.tsx
+++ b/src/test/appStructure.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
 import { availabilityForTypes } from '../core/metricAvailability';
@@ -7,6 +7,7 @@ import { CoachOnboardingScreen } from '../screens/CoachOnboardingScreen';
 import { CoachScreen } from '../screens/CoachScreen';
 import { HistoryScreen } from '../screens/HistoryScreen';
 import { SourceScreen } from '../screens/SourceScreen';
+import { SplashScreen, StartLoadingScreen } from '../screens/SplashScreen';
 import { WorkoutPlanScreen } from '../screens/WorkoutPlanScreen';
 import { DataCard, SmallMetric } from '../ui/primitives';
 import { TabBar } from '../ui/TabBar';
@@ -20,7 +21,29 @@ describe('app module structure', () => {
     expect(typeof AnalyticsScreen).toBe('function');
     expect(typeof HistoryScreen).toBe('function');
     expect(typeof SourceScreen).toBe('function');
+    expect(typeof SplashScreen).toBe('function');
+    expect(typeof StartLoadingScreen).toBe('function');
     expect(typeof TabBar).toBe('function');
+  });
+
+  it('offers splash entry points for onboarding or direct health sync start', () => {
+    const onStartOnboarding = jest.fn();
+    const onSyncAndStart = jest.fn();
+
+    render(<SplashScreen busy={false} onStartOnboarding={onStartOnboarding} onSyncAndStart={onSyncAndStart} sourceLabel="Health Connect" status="Ready" />);
+
+    fireEvent.press(screen.getByText('Onboarding'));
+    fireEvent.press(screen.getByText('Sync data & start'));
+
+    expect(onStartOnboarding).toHaveBeenCalledTimes(1);
+    expect(onSyncAndStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a start loading state while direct sync is running', () => {
+    render(<StartLoadingScreen sourceLabel="Health Connect" status="Syncing Apr 23 to Apr 29" />);
+
+    expect(screen.getByText('Loading')).toBeOnTheScreen();
+    expect(screen.getByText('Syncing Apr 23 to Apr 29')).toBeOnTheScreen();
   });
 
   it('renders shared UI primitives after extraction', () => {

--- a/src/ui/primitives.tsx
+++ b/src/ui/primitives.tsx
@@ -152,7 +152,9 @@ export function CoachLine({ children, first }: { children: string; first?: boole
   return (
     <View style={[styles.coachLine, first && styles.coachLineFirst]}>
       {first ? <CoachAvatar size={32} /> : <View style={styles.coachSpacer} />}
-      <Text style={styles.coachText}>{children}</Text>
+      <View style={styles.coachBubble}>
+        <Text style={styles.coachText}>{children}</Text>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Add a first-run splash screen with two paths: onboarding, or sync data and start.
- Add a loading state while direct start waits for local store bootstrap and device health sync.
- Make AI coach chat bubbles visually consistent with human-entered messages by adding a bubble background and matching text scale.

## Impact
Users can skip onboarding and go straight to the coach after a health data sync, while still seeing explicit loading feedback during device data access.

## Verification
- `npm test -- --runInBand`
- `npm run typecheck`
- `git diff --check HEAD~1 HEAD`
- Web preview smoke: `npx expo start --web -c --port 8082` served `http://localhost:8082` successfully.

Native HealthKit / Health Connect behavior still needs dev-client device verification.