### PR TITLE
[codex] Add AI chat onboarding experience

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,15 @@ import { currentHealthProviderId, currentHealthProviderLabel, syncCurrentPlatfor
 import type { PipelineSnapshot, SyncRange } from './src/health/types';
 import { formatRange, makeSyncRange } from './src/lib/dates';
 import {
+  buildLocalGoalCoachReply,
+  buildLocalOnboardingSummary,
+  sendOnboardingGoalMessage,
+  sendOnboardingSummaryMessage,
+  type GoalCoachMessage,
+  type GoalCoachResponse,
+  type OnboardingAnswers,
+} from './src/onboarding/goalCoach';
+import {
   clearOpenAiApiKey,
   loadAppSettings,
   readOpenAiApiKey,
@@ -219,6 +228,77 @@ export default function App() {
     }
   }
 
+  async function discussOnboardingGoal({
+    conversation,
+    previousResponseId,
+    userMessage,
+  }: {
+    conversation: GoalCoachMessage[];
+    previousResponseId?: string | null;
+    userMessage: string;
+  }): Promise<GoalCoachResponse> {
+    const apiKey = await readOpenAiApiKey();
+
+    if (!apiKey) {
+      setStatus('Onboarding coach is running in local demo mode. Add an OpenAI API key in You for live AI.');
+      return {
+        responseId: null,
+        text: buildLocalGoalCoachReply(userMessage),
+      };
+    }
+
+    const freshSnapshot = await getPipelineSnapshot();
+    setSnapshot(freshSnapshot);
+    setStatus('Onboarding coach is discussing your goal with OpenAI');
+
+    const response = await sendOnboardingGoalMessage({
+      apiKey,
+      conversation,
+      previousResponseId,
+      snapshot: freshSnapshot,
+      userMessage,
+    });
+    setStatus('Onboarding coach updated your goal profile');
+    return response;
+  }
+
+  async function summarizeOnboarding({
+    answers,
+    conversation,
+  }: {
+    answers: OnboardingAnswers;
+    conversation: GoalCoachMessage[];
+  }): Promise<GoalCoachResponse> {
+    const freshSnapshot = await getPipelineSnapshot();
+    setSnapshot(freshSnapshot);
+
+    const apiKey = await readOpenAiApiKey();
+    if (!apiKey) {
+      setStatus('Onboarding summary is running in local demo mode. Add an OpenAI API key in You for live AI.');
+      return {
+        responseId: null,
+        text: buildLocalOnboardingSummary({
+          answers,
+          dataSummary: {
+            coverageDays: freshSnapshot.coverageDays,
+            sleepSessions: freshSnapshot.sleepCount,
+            workouts: freshSnapshot.workoutCount,
+          },
+        }),
+      };
+    }
+
+    setStatus('Onboarding coach is summarising your setup with OpenAI');
+    const response = await sendOnboardingSummaryMessage({
+      apiKey,
+      answers,
+      conversation,
+      snapshot: freshSnapshot,
+    });
+    setStatus('Onboarding summary ready');
+    return response;
+  }
+
   function localCoachFallback(message: string): string {
     const normalized = message.toLowerCase();
     const mentionsPain =
@@ -371,11 +451,13 @@ export default function App() {
           <CoachOnboardingScreen
             busy={busy}
             canSync={canSync}
+            onDiscussGoal={discussOnboardingGoal}
             onComplete={(nextGoal) => {
               setGoalText(nextGoal);
               setEntryMode('app');
               setActiveTab('coach');
             }}
+            onSummarizeOnboarding={summarizeOnboarding}
             onSync={runSync}
             sourceLabel={sourceLabel}
             status={status}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,12 +1,21 @@
-import type { LucideIcon } from 'lucide-react-native';
+import type { LucideIcon } from "lucide-react-native";
 
-import type { CanonicalType } from '../health/types';
-import type { getLastSyncRun, getRecentSyncRuns } from '../storage/trainingStore';
+import type { CanonicalType } from "../health/types";
+import type {
+  getLastSyncRun,
+  getRecentSyncRuns,
+} from "../storage/trainingStore";
 
 export type LastSync = Awaited<ReturnType<typeof getLastSyncRun>>;
 export type SyncRuns = Awaited<ReturnType<typeof getRecentSyncRuns>>;
-export type Tab = 'coach' | 'workout' | 'history' | 'you';
-export type OnboardingStepId = 'data' | 'analysis' | 'goal' | 'event' | 'constraints';
+export type Tab = "coach" | "workout" | "history" | "you";
+export type OnboardingStepId =
+  | "data"
+  | "analysis"
+  | "goal"
+  | "event"
+  | "constraints"
+  | "summary";
 
 export type OnboardingSuggestion = {
   title: string;
@@ -18,14 +27,14 @@ export type OnboardingStep = {
   id: OnboardingStepId;
   question: string;
   subtext: string;
-  suggestions: OnboardingSuggestion[];
+  suggestions?: OnboardingSuggestion[];
 };
 
-export type MetricStatus = 'live' | 'permission' | 'empty' | 'unchecked';
+export type MetricStatus = "live" | "permission" | "empty" | "unchecked";
 
 export type CoachConversationMessage = {
   id: string;
-  role: 'coach' | 'user';
+  role: "coach" | "user";
   text: string;
 };
 

--- a/src/onboarding/goalCoach.test.ts
+++ b/src/onboarding/goalCoach.test.ts
@@ -1,0 +1,45 @@
+import {
+  buildLocalGoalCoachReply,
+  buildLocalOnboardingSummary,
+  goalNeedsEventLookup,
+} from "./goalCoach";
+
+describe("onboarding goal coach", () => {
+  it("asks one useful follow-up for event goals without making the user fill everything in", () => {
+    expect(goalNeedsEventLookup("I want to do HYROX this year")).toBe(true);
+
+    expect(buildLocalGoalCoachReply("I want to do HYROX this year")).toContain(
+      "I’ll look for likely events",
+    );
+  });
+
+  it("keeps non-event goals on an outcome path", () => {
+    expect(goalNeedsEventLookup("I want more energy and better sleep")).toBe(
+      false,
+    );
+
+    expect(
+      buildLocalGoalCoachReply("I want more energy and better sleep"),
+    ).toContain("outcome-led plan");
+  });
+
+  it("summarises onboarding inputs and confirms plan creation", () => {
+    const summary = buildLocalOnboardingSummary({
+      answers: {
+        data: "Connected Apple Health.",
+        analysis: "Looks right.",
+        goal: "Looking to do a marathon.",
+        constraints: "I can train four days a week.",
+      },
+      dataSummary: {
+        coverageDays: 60,
+        sleepSessions: 42,
+        workouts: 18,
+      },
+    });
+
+    expect(summary).toContain("marathon");
+    expect(summary).toContain("four days");
+    expect(summary).toContain("custom plan");
+  });
+});

--- a/src/onboarding/goalCoach.ts
+++ b/src/onboarding/goalCoach.ts
@@ -1,0 +1,307 @@
+import type { PipelineSnapshot } from "../health/types";
+
+const responsesUrl = "https://api.openai.com/v1/responses";
+const onboardingGoalModel = "gpt-5.5";
+
+type OpenAiResponseJson = {
+  id?: unknown;
+  output?: unknown;
+  output_text?: unknown;
+  error?: unknown;
+};
+
+export type GoalCoachMessage = {
+  role: "assistant" | "user";
+  text: string;
+};
+
+export type GoalCoachResponse = {
+  responseId: string | null;
+  text: string;
+};
+
+export type OnboardingAnswers = {
+  analysis?: string;
+  constraints?: string;
+  data?: string;
+  event?: string;
+  goal?: string;
+};
+
+export type OnboardingDataSummary = {
+  coverageDays: number;
+  sleepSessions: number;
+  workouts: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessageFromJson(json: OpenAiResponseJson): string | null {
+  if (!isRecord(json.error)) {
+    return null;
+  }
+
+  const message = json.error.message;
+  return typeof message === "string" ? message : null;
+}
+
+function extractTextFromOutput(output: unknown): string | null {
+  if (!Array.isArray(output)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+
+  for (const item of output) {
+    if (!isRecord(item) || !Array.isArray(item.content)) {
+      continue;
+    }
+
+    for (const content of item.content) {
+      if (isRecord(content) && typeof content.text === "string") {
+        chunks.push(content.text);
+      }
+    }
+  }
+
+  const text = chunks.join("\n").trim();
+  return text || null;
+}
+
+export function goalNeedsEventLookup(goalText: string): boolean {
+  const text = goalText.toLowerCase();
+  return [
+    "event",
+    "race",
+    "competition",
+    "challenge",
+    "hyrox",
+    "marathon",
+    "triathlon",
+    "run",
+  ].some((keyword) => text.includes(keyword));
+}
+
+export function buildLocalGoalCoachReply(goalText: string): string {
+  if (goalNeedsEventLookup(goalText)) {
+    return [
+      "Nice, that gives us a clear target. I’ll look for likely events rather than making you enter every detail manually.",
+      "The useful next thing is the outcome: are you trying to finish comfortably, compete, or hit a specific time?",
+    ].join("\n\n");
+  }
+
+  return [
+    "Got it. I’ll treat this as an outcome-led plan, not force it into a race calendar.",
+    "The useful next thing is what “better” should feel like in daily life: more energy, better sleep, body composition, strength, or consistency?",
+  ].join("\n\n");
+}
+
+export function buildLocalOnboardingSummary({
+  answers,
+  dataSummary,
+}: {
+  answers: OnboardingAnswers;
+  dataSummary: OnboardingDataSummary;
+}): string {
+  const goal =
+    answers.goal?.trim() || "a safer, more personalised training goal";
+  const constraints = answers.constraints?.trim() || "no major constraints yet";
+  const event = answers.event?.trim();
+  const dataLine =
+    dataSummary.coverageDays > 0 ||
+    dataSummary.workouts > 0 ||
+    dataSummary.sleepSessions > 0
+      ? `I’ve got ${dataSummary.coverageDays} days of coverage, ${dataSummary.workouts} workouts, and ${dataSummary.sleepSessions} sleep sessions to work from.`
+      : "I do not have much connected data yet, so I’ll start conservatively and treat the first block as baseline-building.";
+
+  return [
+    `Here’s what I’ve understood: you’re working toward ${goal}${event ? `, with ${event}` : ""}.`,
+    `${dataLine} I’ll also respect this from day one: ${constraints}.`,
+    "I’ll start building a custom plan from your connected data, your goal, and the input you’ve shared, with conservative progression until the baseline is clear.",
+  ].join("\n\n");
+}
+
+function buildSnapshotSummary(snapshot: PipelineSnapshot) {
+  return {
+    samples: snapshot.totalSamples,
+    workouts: snapshot.workoutCount,
+    sleepSessions: snapshot.sleepCount,
+    nutritionDays: snapshot.nutritionDays,
+    coverageDays: snapshot.coverageDays,
+    readiness: snapshot.recommendation.readinessLabel,
+    recentWorkouts: snapshot.recentWorkouts.slice(0, 5).map((workout) => ({
+      name: workout.name ?? workout.activityType ?? "Workout",
+      sport: workout.sportBucket,
+      distanceKm: workout.distanceKm,
+      avgHrBpm: workout.avgHrBpm,
+      startAt: workout.startAt,
+    })),
+  };
+}
+
+function buildGoalCoachInput({
+  conversation,
+  snapshot,
+  userMessage,
+}: {
+  conversation: GoalCoachMessage[];
+  snapshot: PipelineSnapshot;
+  userMessage: string;
+}): string {
+  const recentConversation = conversation.slice(-8);
+
+  return [
+    "Connected data summary:",
+    JSON.stringify(buildSnapshotSummary(snapshot), null, 2),
+    "",
+    "Recent onboarding conversation:",
+    recentConversation.length
+      ? recentConversation
+          .map((turn) => `${turn.role}: ${turn.text}`)
+          .join("\n")
+      : "No previous onboarding conversation.",
+    "",
+    `Latest user answer: ${userMessage}`,
+    "",
+    "Reply as the onboarding coach. Infer the goal branch, explain what you understood, and ask exactly one next question.",
+  ].join("\n");
+}
+
+const onboardingGoalInstructions = [
+  "You are BioStream, an AI-native onboarding coach for a privacy-first fitness app.",
+  "Your job is to discuss the user’s goal naturally while quietly forming a structured goal profile.",
+  "Do not make the user do data entry if the app can infer or look something up later.",
+  "If the user mentions an event, say you can look up likely event details and ask for the smallest useful confirmation or target outcome.",
+  "If the user describes a non-event goal, keep them on an outcome path and ask one practical follow-up.",
+  "Be warm, concise, and specific. Use 2-4 short sentences. Ask exactly one question.",
+  "Do not diagnose, prescribe treatment, or encourage aggressive training. If risk, injury, illness, or long layoff appears, bias toward baseline testing and conservative progression.",
+].join("\n");
+
+const onboardingSummaryInstructions = [
+  "You are BioStream, an AI-native onboarding coach for a privacy-first fitness app.",
+  "Summarise what the user has shared during onboarding and confirm that the app will build a custom plan from connected data plus their stated goal and constraints.",
+  "Be concise, human, and confidence-aware. Do not overstate missing data.",
+  "Mention safety or baseline testing when training history is thin, stale, or the user is returning from time off.",
+  "Use 3 short paragraphs maximum. Do not ask another question.",
+].join("\n");
+
+export async function sendOnboardingGoalMessage({
+  apiKey,
+  conversation,
+  previousResponseId,
+  snapshot,
+  userMessage,
+}: {
+  apiKey: string;
+  conversation: GoalCoachMessage[];
+  previousResponseId?: string | null;
+  snapshot: PipelineSnapshot;
+  userMessage: string;
+}): Promise<GoalCoachResponse> {
+  const payload: Record<string, unknown> = {
+    model: onboardingGoalModel,
+    instructions: onboardingGoalInstructions,
+    input: buildGoalCoachInput({ conversation, snapshot, userMessage }),
+    max_output_tokens: 700,
+    reasoning: { effort: "medium" },
+    truncation: "auto",
+  };
+
+  if (previousResponseId) {
+    payload.previous_response_id = previousResponseId;
+  }
+
+  const response = await fetch(responsesUrl, {
+    body: JSON.stringify(payload),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  const json = (await response.json()) as OpenAiResponseJson;
+
+  if (!response.ok) {
+    throw new Error(
+      errorMessageFromJson(json) ??
+        `OpenAI request failed with ${response.status}`,
+    );
+  }
+
+  const text =
+    (typeof json.output_text === "string" ? json.output_text.trim() : null) ??
+    extractTextFromOutput(json.output);
+
+  if (!text) {
+    throw new Error("OpenAI returned an empty onboarding response.");
+  }
+
+  return {
+    responseId: typeof json.id === "string" ? json.id : null,
+    text,
+  };
+}
+
+export async function sendOnboardingSummaryMessage({
+  apiKey,
+  answers,
+  conversation,
+  snapshot,
+}: {
+  apiKey: string;
+  answers: OnboardingAnswers;
+  conversation: GoalCoachMessage[];
+  snapshot: PipelineSnapshot;
+}): Promise<GoalCoachResponse> {
+  const payload: Record<string, unknown> = {
+    model: onboardingGoalModel,
+    instructions: onboardingSummaryInstructions,
+    input: [
+      "Connected data summary:",
+      JSON.stringify(buildSnapshotSummary(snapshot), null, 2),
+      "",
+      "Onboarding answers:",
+      JSON.stringify(answers, null, 2),
+      "",
+      "Goal conversation:",
+      conversation.length
+        ? conversation.map((turn) => `${turn.role}: ${turn.text}`).join("\n")
+        : "No goal conversation captured.",
+    ].join("\n"),
+    max_output_tokens: 700,
+    reasoning: { effort: "medium" },
+    truncation: "auto",
+  };
+
+  const response = await fetch(responsesUrl, {
+    body: JSON.stringify(payload),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  const json = (await response.json()) as OpenAiResponseJson;
+
+  if (!response.ok) {
+    throw new Error(
+      errorMessageFromJson(json) ??
+        `OpenAI request failed with ${response.status}`,
+    );
+  }
+
+  const text =
+    (typeof json.output_text === "string" ? json.output_text.trim() : null) ??
+    extractTextFromOutput(json.output);
+
+  if (!text) {
+    throw new Error("OpenAI returned an empty onboarding summary.");
+  }
+
+  return {
+    responseId: typeof json.id === "string" ? json.id : null,
+    text,
+  };
+}

--- a/src/onboarding/goalOptions.test.ts
+++ b/src/onboarding/goalOptions.test.ts
@@ -1,0 +1,30 @@
+import { goalOptions, goalQuestion, goalFreeTextPrompt } from "./goalOptions";
+
+describe("goal onboarding options", () => {
+  it("presents MECE goal options with a free-text escape hatch", () => {
+    expect(goalQuestion).toBe(
+      "What are you hoping BioStream helps you achieve?",
+    );
+    expect(goalFreeTextPrompt).toBe("Or tell me in your own words...");
+
+    expect(goalOptions.map((option) => option.title)).toEqual([
+      "Event",
+      "Performance",
+      "Routine",
+      "Body",
+      "Return",
+      "Wellbeing",
+      "Explore",
+    ]);
+
+    expect(goalOptions.map((option) => option.helper)).toEqual([
+      "Race or challenge",
+      "Capability",
+      "Consistency",
+      "Composition",
+      "Restart safely",
+      "Energy and recovery",
+      "AI-guided",
+    ]);
+  });
+});

--- a/src/onboarding/goalOptions.ts
+++ b/src/onboarding/goalOptions.ts
@@ -1,0 +1,55 @@
+export type GoalOption = {
+  title: string;
+  helper: string;
+  prompt: string;
+};
+
+export const goalQuestion = "What are you hoping BioStream helps you achieve?";
+
+export const goalSubtext =
+  "Pick the closest option, or just type it below in your own words. I’ll work out the right path from there.";
+
+export const goalFreeTextPrompt = "Or tell me in your own words...";
+
+export const goalOptions: GoalOption[] = [
+  {
+    title: "Event",
+    helper: "Race or challenge",
+    prompt:
+      "I am preparing for a specific race, competition, or fitness challenge.",
+  },
+  {
+    title: "Performance",
+    helper: "Capability",
+    prompt:
+      "I want to improve a fitness capability like speed, strength, endurance, or power.",
+  },
+  {
+    title: "Routine",
+    helper: "Consistency",
+    prompt: "I want to build consistency and make training part of my life.",
+  },
+  {
+    title: "Body",
+    helper: "Composition",
+    prompt:
+      "I want to change my body composition, weight, muscle, or appearance safely.",
+  },
+  {
+    title: "Return",
+    helper: "Restart safely",
+    prompt:
+      "I am coming back after time off, injury, illness, or a major life change.",
+  },
+  {
+    title: "Wellbeing",
+    helper: "Energy and recovery",
+    prompt:
+      "I want more energy, better sleep, less stress, or better recovery.",
+  },
+  {
+    title: "Explore",
+    helper: "AI-guided",
+    prompt: "I am not sure yet. Help me work out the right goal from my data.",
+  },
+];

--- a/src/onboarding/quickReplies.test.ts
+++ b/src/onboarding/quickReplies.test.ts
@@ -1,0 +1,27 @@
+import { getOnboardingQuickReplies } from "./quickReplies";
+
+describe("onboarding quick replies", () => {
+  it("keeps goal suggestions compact enough for pill UI", () => {
+    const replies = getOnboardingQuickReplies({
+      sourceLabel: "Apple Health",
+      stepId: "goal",
+    });
+
+    expect(replies.map((reply) => reply.label)).toEqual([
+      "Marathon",
+      "HYROX",
+      "Get consistent",
+      "Not sure yet",
+    ]);
+    expect(replies.every((reply) => reply.label.length <= 16)).toBe(true);
+  });
+
+  it("does not show quick replies on the summary step", () => {
+    expect(
+      getOnboardingQuickReplies({
+        sourceLabel: "Apple Health",
+        stepId: "summary",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/onboarding/quickReplies.ts
+++ b/src/onboarding/quickReplies.ts
@@ -1,0 +1,125 @@
+export type OnboardingQuickReply = {
+  label: string;
+  prompt: string;
+};
+
+export type OnboardingQuickReplyStep =
+  | "analysis"
+  | "constraints"
+  | "data"
+  | "event"
+  | "goal"
+  | "summary";
+
+export function getOnboardingQuickReplies({
+  eventGoal,
+  sourceLabel,
+  stepId,
+}: {
+  eventGoal?: boolean;
+  sourceLabel: string;
+  stepId: OnboardingQuickReplyStep;
+}): OnboardingQuickReply[] {
+  if (stepId === "data") {
+    return [
+      {
+        label: "Connect data",
+        prompt: `Connect ${sourceLabel} and analyse my wearable and workout history first.`,
+      },
+      {
+        label: "Skip for now",
+        prompt:
+          "Skip data connection for now. Start with safe assumptions and ask me later.",
+      },
+    ];
+  }
+
+  if (stepId === "analysis") {
+    return [
+      {
+        label: "Looks right",
+        prompt: "That looks right. Use this analysis as the starting point.",
+      },
+      {
+        label: "Keep it safe",
+        prompt:
+          "Be conservative until you have more reliable training history.",
+      },
+    ];
+  }
+
+  if (stepId === "goal") {
+    return [
+      {
+        label: "Marathon",
+        prompt: "I am looking to do a marathon.",
+      },
+      {
+        label: "HYROX",
+        prompt: "I am looking to do HYROX.",
+      },
+      {
+        label: "Get consistent",
+        prompt:
+          "I want to build consistency and make training part of my life.",
+      },
+      {
+        label: "Not sure yet",
+        prompt:
+          "I am not sure yet. Help me work out the right goal from my data.",
+      },
+    ];
+  }
+
+  if (stepId === "event") {
+    return eventGoal
+      ? [
+          {
+            label: "Find it",
+            prompt:
+              "Keep searching for the event using my goal text and location context.",
+          },
+          {
+            label: "No event yet",
+            prompt:
+              "There is no event date yet. Build a sustainable plan around my outcome goal.",
+          },
+        ]
+      : [
+          {
+            label: "That’s right",
+            prompt:
+              "Build my plan around this outcome without an event date for now.",
+          },
+          {
+            label: "Add later",
+            prompt:
+              "Start with this outcome and let me add a race, competition, or challenge later.",
+          },
+        ];
+  }
+
+  if (stepId === "constraints") {
+    return [
+      {
+        label: "4 days/week",
+        prompt: "I can train 4 days per week.",
+      },
+      {
+        label: "Mornings",
+        prompt: "I usually prefer to train before work.",
+      },
+      {
+        label: "Injury concern",
+        prompt:
+          "I have had some niggles, so keep the first few weeks conservative.",
+      },
+      {
+        label: "No constraints",
+        prompt: "No other constraints for now.",
+      },
+    ];
+  }
+
+  return [];
+}

--- a/src/screens/CoachOnboardingScreen.tsx
+++ b/src/screens/CoachOnboardingScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -7,21 +7,49 @@ import {
   Text,
   TextInput,
   View,
-} from 'react-native';
-import { ArrowRight, MoreHorizontal, RefreshCw } from 'lucide-react-native';
+} from "react-native";
+import {
+  ArrowRight,
+  MoreHorizontal,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react-native";
 
-import { formatNumber } from '../core/formatters';
-import { resolveOnboardingEvent } from '../core/onboarding';
-import type { OnboardingStep, OnboardingStepId, OnboardingSuggestion } from '../core/types';
-import type { PipelineSnapshot } from '../health/types';
-import { styles } from '../styles/appStyles';
-import { tokens } from '../theme/tokens';
-import { AppButton, CoachAvatar, CoachLine, DataCard, SectionLabel, SmallMetric, UserBubble } from '../ui/primitives';
+import { formatNumber } from "../core/formatters";
+import { resolveOnboardingEvent } from "../core/onboarding";
+import type {
+  OnboardingStep,
+  OnboardingStepId,
+  OnboardingSuggestion,
+} from "../core/types";
+import type { PipelineSnapshot } from "../health/types";
+import {
+  buildLocalGoalCoachReply,
+  buildLocalOnboardingSummary,
+  goalNeedsEventLookup,
+  type GoalCoachMessage,
+  type GoalCoachResponse,
+  type OnboardingAnswers,
+} from "../onboarding/goalCoach";
+import { goalFreeTextPrompt, goalQuestion } from "../onboarding/goalOptions";
+import { getOnboardingQuickReplies } from "../onboarding/quickReplies";
+import { styles } from "../styles/appStyles";
+import { tokens } from "../theme/tokens";
+import {
+  AppButton,
+  CoachAvatar,
+  CoachLine,
+  DataCard,
+  SmallMetric,
+  UserBubble,
+} from "../ui/primitives";
 
 export function CoachOnboardingScreen({
   busy,
   canSync,
+  onDiscussGoal,
   onComplete,
+  onSummarizeOnboarding,
   onSync,
   sourceLabel,
   status,
@@ -29,27 +57,49 @@ export function CoachOnboardingScreen({
 }: {
   busy: boolean;
   canSync: boolean;
+  onDiscussGoal: (request: {
+    conversation: GoalCoachMessage[];
+    previousResponseId?: string | null;
+    userMessage: string;
+  }) => Promise<GoalCoachResponse>;
   onComplete: (goal: string) => void;
+  onSummarizeOnboarding: (request: {
+    answers: OnboardingAnswers;
+    conversation: GoalCoachMessage[];
+  }) => Promise<GoalCoachResponse>;
   onSync: () => void;
   sourceLabel: string;
   status: string;
   snapshot: PipelineSnapshot;
 }) {
   const [activeStepIndex, setActiveStepIndex] = useState(0);
-  const [composerDraft, setComposerDraft] = useState('');
-  const [goalText, setGoalText] = useState('');
+  const [composerDraft, setComposerDraft] = useState("");
+  const [goalText, setGoalText] = useState("");
+  const [goalCoachBusy, setGoalCoachBusy] = useState(false);
+  const [goalCoachMessages, setGoalCoachMessages] = useState<
+    GoalCoachMessage[]
+  >([]);
+  const [goalCoachResponseId, setGoalCoachResponseId] = useState<string | null>(
+    null,
+  );
+  const [summaryBusy, setSummaryBusy] = useState(false);
+  const [summaryText, setSummaryText] = useState("");
   const [answers, setAnswers] = useState<Record<OnboardingStepId, string>>({
-    data: '',
-    analysis: '',
-    goal: '',
-    event: '',
-    constraints: '',
+    data: "",
+    analysis: "",
+    goal: "",
+    event: "",
+    constraints: "",
+    summary: "",
   });
   const athleteName: string | undefined = undefined;
   const welcomeLine = athleteName
     ? `Hello ${athleteName}, welcome to BioStream.`
-    : 'Hello, welcome to BioStream.';
+    : "Hello, welcome to BioStream.";
   const connectLabel = `Connect ${sourceLabel}`;
+  const dataActionLabel = canSync
+    ? connectLabel
+    : "Continue with demo baseline";
   const eventMatch = resolveOnboardingEvent(goalText);
   const hasSyncedData =
     snapshot.totalSamples > 0 ||
@@ -58,17 +108,22 @@ export function CoachOnboardingScreen({
     snapshot.nutritionDays > 0 ||
     snapshot.coverageDays > 0;
   const analysisQuestion = hasSyncedData
-    ? 'I’ve analysed your connected history. Here’s what I can see so far.'
-    : 'I don’t have wearable history yet, so I’ll start conservatively and treat this as a baseline-first setup.';
+    ? "I’ve analysed your connected history. Here’s what I can see so far."
+    : "I don’t have wearable history yet, so I’ll start conservatively and treat this as a baseline-first setup.";
   const analysisSubtext = hasSyncedData
     ? `I found ${formatNumber(snapshot.totalSamples)} records, ${formatNumber(snapshot.workoutCount)} workouts, and ${formatNumber(snapshot.sleepCount)} sleep nights. I’ll use this to avoid over-prescribing.`
-    : 'You can still continue. Once you connect Apple Health or Health Connect, I’ll replace assumptions with real sleep, recovery, and training history.';
+    : "You can still continue. Once you connect Apple Health or Health Connect, I’ll replace assumptions with real sleep, recovery, and training history.";
+  const isEventGoal = goalNeedsEventLookup(goalText) || Boolean(eventMatch);
   const eventQuestion = eventMatch
     ? `I found a likely match: ${eventMatch.name}. Is this the one?`
-    : 'I could not confidently match an event yet. I can keep searching while we start with a safe first block.';
+    : isEventGoal
+      ? "I can help find the event instead of making you fill in the details."
+      : "Got it. I’ll shape the plan around that outcome rather than forcing it into an event.";
   const eventSubtext = eventMatch
     ? `${eventMatch.date} · ${eventMatch.location} · ${eventMatch.confidence} match from the ${eventMatch.source}.`
-    : 'If you name the city or organiser, I will try to resolve the event automatically instead of making you fill in the details.';
+    : isEventGoal
+      ? "If you know the event name, city, organiser, or rough timing, type it below and I’ll try to resolve the rest."
+      : "If that changes later, we can attach an event or target date without restarting your setup.";
   const eventSuggestions: OnboardingSuggestion[] = eventMatch
     ? [
         {
@@ -77,120 +132,150 @@ export function CoachOnboardingScreen({
           prompt: `Use ${eventMatch.name}, ${eventMatch.date}, at ${eventMatch.location}.`,
         },
         {
-          title: 'Different event',
-          helper: 'Keep searching',
-          prompt: 'That is not the right event. Search for another event match before locking the plan.',
+          title: "Different event",
+          helper: "Keep searching",
+          prompt:
+            "That is not the right event. Search for another event match before locking the plan.",
         },
         {
-          title: 'No event',
-          helper: 'Outcome goal',
-          prompt: 'Do not lock an event yet. Build a general training plan around my goal.',
+          title: "No event",
+          helper: "Outcome goal",
+          prompt:
+            "Do not lock an event yet. Build a general training plan around my goal.",
         },
       ]
-    : [
-        {
-          title: 'Keep searching',
-          helper: 'AI lookup',
-          prompt: 'Keep searching for the event using my goal text and location context.',
-        },
-        {
-          title: 'No event',
-          helper: 'Outcome goal',
-          prompt: 'There is no event. Build a sustainable plan around my outcome goal.',
-        },
-      ];
+    : [];
   const steps: OnboardingStep[] = [
     {
-      id: 'data',
+      id: "data",
       question: welcomeLine,
       subtext: `Let’s connect up your data so I can get started. I’ll pull what I can from ${sourceLabel}, look at your recent training, sleep, recovery, and any gaps, then we’ll talk about what you’re working toward.`,
-      suggestions: [
-        {
-          title: connectLabel,
-          helper: sourceLabel,
-          prompt: `Connect ${sourceLabel} and analyse my wearable and workout history first.`,
-        },
-        {
-          title: 'Skip for now',
-          helper: 'Manual start',
-          prompt: 'Skip data connection for now. Start with safe assumptions and ask me later.',
-        },
-      ],
     },
     {
-      id: 'analysis',
+      id: "analysis",
       question: analysisQuestion,
       subtext: analysisSubtext,
-      suggestions: [
-        {
-          title: 'Looks right',
-          helper: 'Continue',
-          prompt: 'That looks right. Use this analysis as the starting point.',
-        },
-        {
-          title: 'Be conservative',
-          helper: 'Safety first',
-          prompt: 'Be conservative until you have more reliable training history.',
-        },
-      ],
     },
     {
-      id: 'goal',
-      question: 'Now, what event or outcome are we training for?',
-      subtext: 'You can answer naturally. I’ll resolve events myself where I can, then ask only for the details I cannot infer.',
-      suggestions: [
-        {
-          title: 'HYROX',
-          helper: 'Event goal',
-          prompt: 'I am training for HYROX and want to finish under 90 minutes.',
-        },
-        {
-          title: 'Run event',
-          helper: 'Race goal',
-          prompt: 'I am training for a half marathon and want to finish under 2 hours.',
-        },
-        {
-          title: 'Strength',
-          helper: 'Training goal',
-          prompt: 'I want to build strength and train 4 days a week.',
-        },
-      ],
+      id: "goal",
+      question: goalQuestion,
+      subtext:
+        "What’s the thing you’d like to be ready for, or the change you want to feel first?",
     },
     {
-      id: 'event',
+      id: "event",
       question: eventQuestion,
       subtext: eventSubtext,
       suggestions: eventSuggestions,
     },
     {
-      id: 'constraints',
-      question: 'Any constraints I should respect from day one?',
-      subtext: 'Injuries, equipment access, schedule, recovery, travel, and preferred training days change the plan more than people expect.',
-      suggestions: [
-        {
-          title: 'Equipment',
-          helper: 'HYROX readiness',
-          prompt: 'I have gym access but not always sleds or ski erg.',
-        },
-        {
-          title: 'Schedule',
-          helper: 'Availability',
-          prompt: 'I can train 4 days per week, usually before work.',
-        },
-        {
-          title: 'Injury risk',
-          helper: 'Guardrail',
-          prompt: 'I have had some niggles, so keep the first few weeks conservative.',
-        },
-      ],
+      id: "constraints",
+      question: "Any constraints I should respect from day one?",
+      subtext:
+        "Injuries, equipment access, schedule, recovery, travel, and preferred training days change the plan more than people expect.",
+    },
+    {
+      id: "summary",
+      question: "Here’s what I’ll use to build your plan.",
+      subtext:
+        summaryText || "I’m summarising your data, goal, and constraints now.",
     },
   ];
   const activeStep = steps[activeStepIndex] ?? steps[0]!;
   const activeAnswer = answers[activeStep.id];
   const canSend = composerDraft.trim().length > 2;
-  const isDataStep = activeStep.id === 'data';
-  const isFinalStep = activeStep.id === 'constraints';
-  const completedSteps = steps.slice(0, activeStepIndex).filter((step) => Boolean(answers[step.id]));
+  const isDataStep = activeStep.id === "data";
+  const isGoalStep = activeStep.id === "goal";
+  const isFinalStep = activeStep.id === "constraints";
+  const isSummaryStep = activeStep.id === "summary";
+  const completedSteps = steps
+    .slice(0, activeStepIndex)
+    .filter((step) => Boolean(answers[step.id]));
+  const quickReplies = getOnboardingQuickReplies({
+    eventGoal: isEventGoal,
+    sourceLabel,
+    stepId: activeStep.id,
+  });
+
+  function continueFromGoal() {
+    if (!goalText.trim()) return;
+    setActiveStepIndex((index) => Math.min(index + 1, steps.length - 1));
+  }
+
+  async function discussGoal(nextValue: string) {
+    const userMessage: GoalCoachMessage = { role: "user", text: nextValue };
+    const requestConversation = [...goalCoachMessages, userMessage];
+
+    setGoalText(nextValue);
+    setAnswers((current) => ({
+      ...current,
+      goal: nextValue,
+    }));
+    setGoalCoachMessages(requestConversation);
+    setGoalCoachBusy(true);
+
+    try {
+      const response = await onDiscussGoal({
+        conversation: requestConversation,
+        previousResponseId: goalCoachResponseId,
+        userMessage: nextValue,
+      });
+      setGoalCoachResponseId(response.responseId);
+      setGoalCoachMessages((messages) => [
+        ...messages,
+        { role: "assistant", text: response.text },
+      ]);
+    } catch {
+      setGoalCoachMessages((messages) => [
+        ...messages,
+        {
+          role: "assistant",
+          text: `${buildLocalGoalCoachReply(nextValue)}\n\nI could not reach the AI coach just then, so I kept this in demo mode.`,
+        },
+      ]);
+    } finally {
+      setGoalCoachBusy(false);
+    }
+  }
+
+  async function summarizeOnboarding(nextConstraints: string) {
+    const nextAnswers = {
+      ...answers,
+      constraints: nextConstraints,
+    };
+
+    setSummaryBusy(true);
+    setSummaryText("");
+    setActiveStepIndex((index) => Math.min(index + 1, steps.length - 1));
+
+    try {
+      const response = await onSummarizeOnboarding({
+        answers: nextAnswers,
+        conversation: goalCoachMessages,
+      });
+      setSummaryText(response.text);
+      setAnswers((current) => ({
+        ...current,
+        summary: response.text,
+      }));
+    } catch {
+      const text = buildLocalOnboardingSummary({
+        answers: nextAnswers,
+        dataSummary: {
+          coverageDays: snapshot.coverageDays,
+          sleepSessions: snapshot.sleepCount,
+          workouts: snapshot.workoutCount,
+        },
+      });
+      setSummaryText(text);
+      setAnswers((current) => ({
+        ...current,
+        summary: text,
+      }));
+    } finally {
+      setSummaryBusy(false);
+    }
+  }
 
   function answerStep(value: string) {
     const nextValue = value.trim();
@@ -200,22 +285,28 @@ export function CoachOnboardingScreen({
       ...current,
       [activeStep.id]: nextValue,
     }));
-    setComposerDraft('');
+    setComposerDraft("");
 
-    if (activeStep.id === 'goal') {
-      setGoalText(nextValue);
+    if (activeStep.id === "goal") {
+      void discussGoal(nextValue);
+      return;
     }
 
-    if (activeStep.id === 'data') {
-      if (nextValue.toLowerCase().includes('connect')) {
+    if (activeStep.id === "data") {
+      if (canSync && nextValue.toLowerCase().includes("connect")) {
         onSync();
       }
       setActiveStepIndex((index) => Math.min(index + 1, steps.length - 1));
       return;
     }
 
-    if (activeStep.id === 'constraints') {
-      onComplete(goalText || 'Training with recovery-aware adjustments.');
+    if (activeStep.id === "constraints") {
+      void summarizeOnboarding(nextValue);
+      return;
+    }
+
+    if (activeStep.id === "summary") {
+      onComplete(goalText || "Training with recovery-aware adjustments.");
       return;
     }
 
@@ -224,7 +315,7 @@ export function CoachOnboardingScreen({
 
   return (
     <KeyboardAvoidingView
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
       style={styles.screen}
     >
       <View style={styles.topBar}>
@@ -259,95 +350,183 @@ export function CoachOnboardingScreen({
         {completedSteps.map((step) => (
           <View key={step.id} style={styles.onboardingThreadBlock}>
             <CoachLine>{step.question}</CoachLine>
-            <UserBubble>{answers[step.id] ?? ''}</UserBubble>
+            <UserBubble>{answers[step.id] ?? ""}</UserBubble>
           </View>
         ))}
 
         <CoachLine>{activeStep.question}</CoachLine>
-        <DataCard accent={tokens.ink} inset label={activeStep.id === 'data' ? 'Datasource' : 'Coach setup'}>
+        <DataCard
+          accent={tokens.ink}
+          inset
+          label={activeStep.id === "data" ? "Datasource" : "Coach setup"}
+        >
           <Text style={styles.helpText}>{activeStep.subtext}</Text>
-          {activeStep.id === 'analysis' ? (
+          {activeStep.id === "analysis" ? (
             <View style={styles.metricGridFull}>
-              <SmallMetric label="Records" value={formatNumber(snapshot.totalSamples)} />
-              <SmallMetric label="Workouts" value={formatNumber(snapshot.workoutCount)} />
-              <SmallMetric label="Sleep" value={formatNumber(snapshot.sleepCount)} />
-              <SmallMetric label="Readiness" value={snapshot.recommendation.readinessLabel} />
+              <SmallMetric
+                label="Records"
+                value={formatNumber(snapshot.totalSamples)}
+              />
+              <SmallMetric
+                label="Workouts"
+                value={formatNumber(snapshot.workoutCount)}
+              />
+              <SmallMetric
+                label="Sleep"
+                value={formatNumber(snapshot.sleepCount)}
+              />
+              <SmallMetric
+                label="Readiness"
+                value={snapshot.recommendation.readinessLabel}
+              />
             </View>
           ) : null}
-          {activeStep.id === 'data' ? (
+          {activeStep.id === "data" ? (
             <View style={styles.singleAction}>
               <AppButton
-                disabled={!canSync || busy}
+                disabled={busy}
                 icon={RefreshCw}
-                label={busy ? status : connectLabel}
-                onPress={() => answerStep(`Connect ${sourceLabel} now.`)}
+                label={busy ? status : dataActionLabel}
+                onPress={() =>
+                  answerStep(
+                    canSync
+                      ? `Connect ${sourceLabel} now.`
+                      : "Continue with a conservative demo baseline until native health data is connected.",
+                  )
+                }
+                variant="primary"
+              />
+            </View>
+          ) : null}
+          {activeStep.id === "goal" ? (
+            <Text style={styles.setupFreeTextHint}>{goalFreeTextPrompt}</Text>
+          ) : null}
+          {activeStep.id === "summary" ? (
+            <View style={styles.singleAction}>
+              <AppButton
+                disabled={summaryBusy || !summaryText.trim()}
+                icon={Sparkles}
+                label={summaryBusy ? "Summarising..." : "Start plan"}
+                onPress={() => answerStep(summaryText || "Start plan")}
                 variant="primary"
               />
             </View>
           ) : null}
         </DataCard>
 
-        {!activeAnswer ? (
-          <View style={styles.suggestedReplyWrap}>
-            <SectionLabel>Suggested replies</SectionLabel>
-            <View style={styles.setupCardGrid}>
-              {activeStep.suggestions.map((suggestion) => (
-                <Pressable
-                  accessibilityRole="button"
-                  key={suggestion.title}
-                  onPress={() => answerStep(suggestion.prompt)}
-                  style={({ pressed }) => [styles.setupOptionCard, pressed && styles.pressed]}
-                >
-                  <Text style={styles.setupOptionTitle}>{suggestion.title}</Text>
-                  <Text style={styles.setupOptionHelper}>{suggestion.helper}</Text>
-                  <Text style={styles.setupOptionText}>{suggestion.prompt}</Text>
-                </Pressable>
-              ))}
-            </View>
+        {isGoalStep && goalCoachMessages.length ? (
+          <View style={styles.goalCoachThread}>
+            {goalCoachMessages.map((message, index) =>
+              message.role === "user" ? (
+                <UserBubble key={`${message.role}-${index}`}>
+                  {message.text}
+                </UserBubble>
+              ) : (
+                <CoachLine key={`${message.role}-${index}`}>
+                  {message.text}
+                </CoachLine>
+              ),
+            )}
+            {goalCoachBusy ? (
+              <CoachLine>Thinking through your goal...</CoachLine>
+            ) : null}
+            {!goalCoachBusy ? (
+              <View style={styles.goalContinueRow}>
+                <AppButton
+                  disabled={!goalText.trim()}
+                  icon={ArrowRight}
+                  label="Continue"
+                  onPress={continueFromGoal}
+                  variant="primary"
+                />
+              </View>
+            ) : null}
           </View>
         ) : null}
       </ScrollView>
 
-      <View style={styles.composer}>
-        <View style={styles.composerInput}>
-          <TextInput
-            accessibilityLabel="Message your coach"
-            autoCorrect
-            cursorColor={tokens.ink}
-            onChangeText={setComposerDraft}
-            onSubmitEditing={() => {
-              if (canSend) answerStep(composerDraft);
+      <View style={[styles.composer, styles.onboardingComposer]}>
+        {quickReplies.length && !isSummaryStep ? (
+          <ScrollView
+            contentContainerStyle={styles.quickReplyRailContent}
+            horizontal
+            keyboardShouldPersistTaps="handled"
+            showsHorizontalScrollIndicator={false}
+            style={styles.quickReplyRail}
+          >
+            {quickReplies.map((reply) => (
+              <Pressable
+                accessibilityLabel={`Suggested reply: ${reply.label}`}
+                accessibilityRole="button"
+                disabled={goalCoachBusy}
+                key={reply.label}
+                onPress={() => answerStep(reply.prompt)}
+                style={({ pressed }) => [
+                  styles.quickReplyPill,
+                  goalCoachBusy && styles.disabled,
+                  pressed && styles.pressed,
+                ]}
+              >
+                <Text style={styles.quickReplyText}>{reply.label}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        ) : null}
+        <View style={styles.composerRow}>
+          <View style={styles.composerInput}>
+            <TextInput
+              accessibilityLabel="Message your coach"
+              autoCorrect
+              cursorColor={tokens.ink}
+              editable={!isSummaryStep}
+              onChangeText={setComposerDraft}
+              onSubmitEditing={() => {
+                if (canSend) answerStep(composerDraft);
+              }}
+              placeholder={
+                isSummaryStep
+                  ? "Ready when the summary is finished"
+                  : isDataStep
+                    ? `Connect ${sourceLabel} or skip...`
+                    : "Message your coach..."
+              }
+              placeholderTextColor={tokens.muted}
+              returnKeyType="send"
+              selectionColor={tokens.ink}
+              style={styles.composerTextInput}
+              value={composerDraft}
+            />
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            disabled={
+              isSummaryStep ||
+              goalCoachBusy ||
+              (!isDataStep && !isFinalStep && !canSend)
+            }
+            onPress={() => {
+              if (isDataStep && !composerDraft.trim()) {
+                answerStep("Skip data connection for now.");
+                return;
+              }
+              if (isFinalStep && !composerDraft.trim()) {
+                answerStep("No other constraints for now.");
+                return;
+              }
+              answerStep(composerDraft);
             }}
-            placeholder={isDataStep ? `Connect ${sourceLabel} or skip...` : 'Message your coach...'}
-            placeholderTextColor={tokens.muted}
-            returnKeyType="send"
-            selectionColor={tokens.ink}
-            style={styles.composerTextInput}
-            value={composerDraft}
-          />
+            style={({ pressed }) => [
+              styles.sendButton,
+              (isSummaryStep ||
+                goalCoachBusy ||
+                (!isDataStep && !isFinalStep && !canSend)) &&
+                styles.disabled,
+              pressed && styles.pressed,
+            ]}
+          >
+            <ArrowRight color={tokens.surface} size={18} strokeWidth={2.3} />
+          </Pressable>
         </View>
-        <Pressable
-          accessibilityRole="button"
-          disabled={!isDataStep && !isFinalStep && !canSend}
-          onPress={() => {
-            if (isDataStep && !composerDraft.trim()) {
-              answerStep('Skip data connection for now.');
-              return;
-            }
-            if (isFinalStep && !composerDraft.trim()) {
-              answerStep('No other constraints for now.');
-              return;
-            }
-            answerStep(composerDraft);
-          }}
-          style={({ pressed }) => [
-            styles.sendButton,
-            !isDataStep && !isFinalStep && !canSend && styles.disabled,
-            pressed && styles.pressed,
-          ]}
-        >
-          <ArrowRight color={tokens.surface} size={18} strokeWidth={2.3} />
-        </Pressable>
       </View>
     </KeyboardAvoidingView>
   );

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -173,6 +173,20 @@ export const styles = StyleSheet.create({
     letterSpacing: 0,
     lineHeight: 19,
   },
+  setupFreeTextHint: {
+    color: tokens.muted,
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0,
+    lineHeight: 18,
+    marginTop: 12,
+  },
+  goalCoachThread: {
+    gap: 10,
+  },
+  goalContinueRow: {
+    marginLeft: 42,
+  },
   topBar: {
     alignItems: 'center',
     borderBottomColor: tokens.lineSoft,
@@ -580,6 +594,39 @@ export const styles = StyleSheet.create({
     borderBottomWidth: 1,
     paddingHorizontal: 14,
     paddingVertical: 10,
+  },
+  onboardingComposer: {
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  quickReplyRail: {
+    maxHeight: 34,
+  },
+  quickReplyRailContent: {
+    gap: 8,
+    paddingRight: 2,
+  },
+  quickReplyPill: {
+    alignItems: 'center',
+    backgroundColor: tokens.surface,
+    borderColor: tokens.line,
+    borderRadius: 99,
+    borderWidth: 1,
+    height: 32,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  quickReplyText: {
+    color: tokens.ink,
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 0,
+  },
+  composerRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
   },
   composerInput: {
     backgroundColor: tokens.surface,


### PR DESCRIPTION
## Summary
- Converts onboarding into a chat-first AI coaching flow instead of large decision cards.
- Adds OpenAI-backed goal discussion and onboarding summary helpers, with local demo fallbacks when no API key is saved.
- Adds compact quick-reply pills above the composer and keeps web prototypes unblocked with a demo-baseline data step.

## Scope
This PR is limited to the onboarding experience and its supporting helpers/tests.

## Validation
- npm run typecheck
- npm test -- --runInBand
- git diff --cached --check before commit
