### PR TITLE
[codex] Fix Android safe-area spacing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  SafeAreaView,
+  View,
 } from "react-native";
 
 import { openAiCoachModel, sendCoachMessage } from "./src/ai/openaiCoach";
@@ -512,7 +512,7 @@ export default function App() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <StatusBar style="dark" />
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : "height"}
@@ -599,6 +599,6 @@ export default function App() {
           <TabBar active={activeTab} onChange={setActiveTab} />
         ) : null}
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </View>
   );
 }

--- a/src/ui/TabBar.tsx
+++ b/src/ui/TabBar.tsx
@@ -1,20 +1,39 @@
-import { Pressable, Text, View } from 'react-native';
-import { Dumbbell, History, Sparkles, User, type LucideIcon } from 'lucide-react-native';
+import { Platform, Pressable, Text, View } from "react-native";
+import {
+  Dumbbell,
+  History,
+  Sparkles,
+  User,
+  type LucideIcon,
+} from "lucide-react-native";
 
-import type { Tab } from '../core/types';
-import { styles } from '../styles/appStyles';
-import { tokens } from '../theme/tokens';
+import type { Tab } from "../core/types";
+import { styles } from "../styles/appStyles";
+import { tokens } from "../theme/tokens";
 
-export function TabBar({ active, onChange }: { active: Tab; onChange: (tab: Tab) => void }) {
+const androidGestureInset = Platform.OS === "android" ? 14 : 0;
+
+export function TabBar({
+  active,
+  onChange,
+}: {
+  active: Tab;
+  onChange: (tab: Tab) => void;
+}) {
   const tabs: { id: Tab; label: string; icon: LucideIcon }[] = [
-    { id: 'coach', label: 'Coach', icon: Sparkles },
-    { id: 'workout', label: 'Workout', icon: Dumbbell },
-    { id: 'history', label: 'History', icon: History },
-    { id: 'you', label: 'You', icon: User },
+    { id: "coach", label: "Coach", icon: Sparkles },
+    { id: "workout", label: "Workout", icon: Dumbbell },
+    { id: "history", label: "History", icon: History },
+    { id: "you", label: "You", icon: User },
   ];
 
   return (
-    <View style={styles.tabBar}>
+    <View
+      style={[
+        styles.tabBar,
+        androidGestureInset > 0 && { paddingBottom: 5 + androidGestureInset },
+      ]}
+    >
       {tabs.map((tab) => {
         const activeTab = active === tab.id;
         const Icon = tab.icon;

--- a/src/ui/TabBar.tsx
+++ b/src/ui/TabBar.tsx
@@ -1,39 +1,22 @@
-import { Platform, Pressable, Text, View } from "react-native";
-import {
-  Dumbbell,
-  History,
-  Sparkles,
-  User,
-  type LucideIcon,
-} from "lucide-react-native";
+import { Platform, Pressable, Text, View } from 'react-native';
+import { Dumbbell, History, Sparkles, User, type LucideIcon } from 'lucide-react-native';
 
-import type { Tab } from "../core/types";
-import { styles } from "../styles/appStyles";
-import { tokens } from "../theme/tokens";
+import type { Tab } from '../core/types';
+import { styles } from '../styles/appStyles';
+import { tokens } from '../theme/tokens';
 
-const androidGestureInset = Platform.OS === "android" ? 14 : 0;
+const androidGestureInset = Platform.OS === 'android' ? 14 : 0;
 
-export function TabBar({
-  active,
-  onChange,
-}: {
-  active: Tab;
-  onChange: (tab: Tab) => void;
-}) {
+export function TabBar({ active, onChange }: { active: Tab; onChange: (tab: Tab) => void }) {
   const tabs: { id: Tab; label: string; icon: LucideIcon }[] = [
-    { id: "coach", label: "Coach", icon: Sparkles },
-    { id: "workout", label: "Workout", icon: Dumbbell },
-    { id: "history", label: "History", icon: History },
-    { id: "you", label: "You", icon: User },
+    { id: 'coach', label: 'Coach', icon: Sparkles },
+    { id: 'workout', label: 'Workout', icon: Dumbbell },
+    { id: 'history', label: 'History', icon: History },
+    { id: 'you', label: 'You', icon: User },
   ];
 
   return (
-    <View
-      style={[
-        styles.tabBar,
-        androidGestureInset > 0 && { paddingBottom: 5 + androidGestureInset },
-      ]}
-    >
+    <View style={[styles.tabBar, androidGestureInset > 0 && { paddingBottom: 5 + androidGestureInset }]}>
       {tabs.map((tab) => {
         const activeTab = active === tab.id;
         const Icon = tab.icon;


### PR DESCRIPTION
## Summary
- replace the root `SafeAreaView` wrapper with a regular `View` so Android uses the existing explicit top inset without the deprecated safe-area behavior
- add a small Android-only bottom padding inside the tab bar background, keeping the gesture area visually attached to the tab bar instead of a separate white band

## Issues
Closes #52
Closes #56

## Verification
- Confirmed on Pixel 9 Pro dev client via `METRO_PORT=8083 bash scripts/start-android-dev-client.sh 47121FDAP00123`; user verified the top/bottom spacing looked good
- `git diff --check origin/main..HEAD`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run test:rollups`
