### PR TITLE
Track B training state classifier

### DIFF
--- a/src/coach/trainingState.test.ts
+++ b/src/coach/trainingState.test.ts
@@ -1,0 +1,145 @@
+import type { WorkoutRecord } from "../health/types";
+import type { RiskFlags } from "./schemas";
+import { classifyTrainingState } from "./trainingState";
+
+const asOfDate = "2026-04-29";
+
+function workout(
+  daysAgo: number,
+  overrides: Partial<WorkoutRecord> = {},
+): WorkoutRecord {
+  const date = new Date(`${asOfDate}T12:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - daysAgo);
+  const localDate = date.toISOString().slice(0, 10);
+
+  return {
+    workoutId: `workout-${daysAgo}-${overrides.sportBucket ?? "run"}`,
+    platform: "health_connect",
+    startAt: `${localDate}T08:00:00.000Z`,
+    endAt: `${localDate}T08:45:00.000Z`,
+    localDate,
+    sportBucket: "run",
+    elapsedSeconds: 45 * 60,
+    rawJson: "{}",
+    ...overrides,
+  };
+}
+
+function riskFlags(overrides: Partial<RiskFlags> = {}): RiskFlags {
+  return {
+    generated_at: "2026-04-29T12:00:00.000Z",
+    highest_severity: "none",
+    has_blocking_risk: false,
+    summary: "No risk flags were supplied.",
+    items: [],
+    ...overrides,
+  };
+}
+
+describe("training state classifier", () => {
+  it("classifies no workout and no check-in data as unknown with lower recommendation confidence", () => {
+    const state = classifyTrainingState({ asOfDate });
+
+    expect(state.state).toBe("unknown");
+    expect(state.confidence).toBeLessThanOrEqual(0.35);
+    expect(state.recommendationConfidenceMultiplier).toBeLessThan(1);
+    expect(state.explanation).toMatch(/not enough/i);
+  });
+
+  it("classifies an explicit beginner check-in with no workout history as first-time athlete", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      checkIns: [
+        {
+          source: "goal_profile",
+          text: "I am brand new to training and just starting exercise.",
+        },
+      ],
+    });
+
+    expect(state.state).toBe("first_time_athlete");
+    expect(state.baselineBuildingRecommended).toBe(true);
+    expect(state.recommendedBehavior).toBe("baseline_building");
+    expect(state.explanation).toMatch(/first-time/i);
+  });
+
+  it("classifies recent activity after an extended gap as returning after extended gap", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [workout(2), workout(50), workout(65)],
+    });
+
+    expect(state.state).toBe("returning_after_extended_gap");
+    expect(state.baselineBuildingRecommended).toBe(true);
+    expect(state.recommendedBehavior).toBe("baseline_building");
+    expect(state.explanation).toMatch(/gap/i);
+  });
+
+  it("classifies one active day in the last 30 days as inconsistent or low recent activity", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [workout(8), workout(42)],
+    });
+
+    expect(state.state).toBe("inconsistent_or_low_recent_activity");
+    expect(state.activeDaysLast30).toBe(1);
+    expect(state.recommendedBehavior).toBe("baseline_building");
+  });
+
+  it("classifies three recent active days as consistent recreational athlete", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [workout(3), workout(10), workout(17), workout(38)],
+    });
+
+    expect(state.state).toBe("consistent_recreational_athlete");
+    expect(state.activeDaysLast30).toBe(3);
+    expect(state.recommendedBehavior).toBe("normal_progression");
+    expect(state.confidence).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it("classifies high recent frequency and duration as advanced athlete", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [
+        workout(1, { elapsedSeconds: 75 * 60 }),
+        workout(4, { elapsedSeconds: 80 * 60 }),
+        workout(7, { elapsedSeconds: 90 * 60 }),
+        workout(10, { elapsedSeconds: 70 * 60 }),
+        workout(14, { elapsedSeconds: 85 * 60 }),
+        workout(18, { elapsedSeconds: 95 * 60 }),
+        workout(23, { elapsedSeconds: 75 * 60 }),
+        workout(28, { elapsedSeconds: 90 * 60 }),
+      ],
+    });
+
+    expect(state.state).toBe("advanced_athlete");
+    expect(state.activeDaysLast30).toBe(8);
+    expect(state.totalWorkoutMinutesLast30).toBeGreaterThanOrEqual(600);
+    expect(state.recommendedBehavior).toBe("normal_progression");
+  });
+
+  it("classifies blocking risk flags as currently limited even with advanced recent activity", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [
+        workout(1, { elapsedSeconds: 75 * 60 }),
+        workout(4, { elapsedSeconds: 80 * 60 }),
+        workout(7, { elapsedSeconds: 90 * 60 }),
+        workout(10, { elapsedSeconds: 70 * 60 }),
+        workout(14, { elapsedSeconds: 85 * 60 }),
+        workout(18, { elapsedSeconds: 95 * 60 }),
+      ],
+      riskFlags: riskFlags({
+        highest_severity: "high",
+        has_blocking_risk: true,
+        summary: "Detected risk flags for injury concern.",
+      }),
+    });
+
+    expect(state.state).toBe("currently_limited");
+    expect(state.recommendedBehavior).toBe("recovery_or_professional_guidance");
+    expect(state.confidence).toBeGreaterThanOrEqual(0.8);
+    expect(state.explanation).toMatch(/risk/i);
+  });
+});

--- a/src/coach/trainingState.test.ts
+++ b/src/coach/trainingState.test.ts
@@ -138,6 +138,36 @@ describe("training state classifier", () => {
     expect(state.recommendedBehavior).toBe("normal_progression");
   });
 
+  it.each(["no pain today", "doctor cleared me"])(
+    "does not classify non-limiting check-in text as currently limited: %s",
+    (text) => {
+      const state = classifyTrainingState({
+        asOfDate,
+        workouts: [workout(2), workout(9), workout(16), workout(23)],
+        checkIns: [{ source: "daily_check_in", text }],
+      });
+
+      expect(state.state).toBe("consistent_recreational_athlete");
+      expect(state.recommendedBehavior).toBe("normal_progression");
+    },
+  );
+
+  it.each(["sharp pain in my knee", "doctor told me not to train"])(
+    "classifies direct limiting check-in text as currently limited: %s",
+    (text) => {
+      const state = classifyTrainingState({
+        asOfDate,
+        workouts: [workout(2), workout(9), workout(16), workout(23)],
+        checkIns: [{ source: "daily_check_in", text }],
+      });
+
+      expect(state.state).toBe("currently_limited");
+      expect(state.recommendedBehavior).toBe(
+        "recovery_or_professional_guidance",
+      );
+    },
+  );
+
   it("classifies blocking risk flags as currently limited even with advanced recent activity", () => {
     const state = classifyTrainingState({
       asOfDate,

--- a/src/coach/trainingState.test.ts
+++ b/src/coach/trainingState.test.ts
@@ -119,6 +119,25 @@ describe("training state classifier", () => {
     expect(state.recommendedBehavior).toBe("normal_progression");
   });
 
+  it("classifies a currently consistent athlete with an old historical gap by recent training", () => {
+    const state = classifyTrainingState({
+      asOfDate,
+      workouts: [
+        workout(1, { elapsedSeconds: 75 * 60 }),
+        workout(4, { elapsedSeconds: 80 * 60 }),
+        workout(7, { elapsedSeconds: 90 * 60 }),
+        workout(10, { elapsedSeconds: 70 * 60 }),
+        workout(14, { elapsedSeconds: 85 * 60 }),
+        workout(18, { elapsedSeconds: 95 * 60 }),
+        workout(100, { elapsedSeconds: 45 * 60 }),
+      ],
+    });
+
+    expect(state.state).toBe("advanced_athlete");
+    expect(state.baselineBuildingRecommended).toBe(false);
+    expect(state.recommendedBehavior).toBe("normal_progression");
+  });
+
   it("classifies blocking risk flags as currently limited even with advanced recent activity", () => {
     const state = classifyTrainingState({
       asOfDate,

--- a/src/coach/trainingState.ts
+++ b/src/coach/trainingState.ts
@@ -1,0 +1,288 @@
+import type { WorkoutRecord } from "../health/types";
+import type { RiskFlagSeverity, RiskFlags, RiskFlagSource } from "./schemas";
+
+export type TrainingState =
+  | "first_time_athlete"
+  | "returning_after_extended_gap"
+  | "inconsistent_or_low_recent_activity"
+  | "consistent_recreational_athlete"
+  | "advanced_athlete"
+  | "currently_limited"
+  | "unknown";
+
+export type TrainingStateRecommendedBehavior =
+  | "baseline_building"
+  | "normal_progression"
+  | "recovery_or_professional_guidance"
+  | "conservative_discovery";
+
+export type TrainingStateCheckIn = {
+  source: RiskFlagSource;
+  text: string;
+};
+
+export type ClassifyTrainingStateInput = {
+  asOfDate: string;
+  workouts?: readonly WorkoutRecord[];
+  checkIns?: readonly TrainingStateCheckIn[];
+  riskFlags?: RiskFlags | null;
+};
+
+export type TrainingStateClassification = {
+  state: TrainingState;
+  confidence: number;
+  explanation: string;
+  recommendedBehavior: TrainingStateRecommendedBehavior;
+  baselineBuildingRecommended: boolean;
+  recommendationConfidenceMultiplier: number;
+  activeDaysLast30: number;
+  totalWorkoutMinutesLast30: number;
+  longestGapDays: number | null;
+  signalsUsed: string[];
+};
+
+const firstTimePatterns = [
+  /\b(first[-\s]?time|brand new|new to (training|exercise|running|fitness))\b/i,
+  /\b(just starting|never trained|beginner)\b/i,
+];
+
+const limitedPatterns = [
+  /\b(injur(y|ed)|pain|sick|ill|fever|limited|doctor|clinician)\b/i,
+  /\b(recovering from|can't train|cannot train)\b/i,
+];
+
+const severityRank: Record<RiskFlagSeverity, number> = {
+  none: 0,
+  low: 1,
+  moderate: 2,
+  high: 3,
+  urgent: 4,
+};
+
+function parseLocalDate(date: string): Date {
+  return new Date(`${date.slice(0, 10)}T00:00:00.000Z`);
+}
+
+function daysBetween(earlier: string, later: string): number {
+  const earlierTime = parseLocalDate(earlier).getTime();
+  const laterTime = parseLocalDate(later).getTime();
+
+  return Math.floor((laterTime - earlierTime) / 86_400_000);
+}
+
+function uniqueWorkoutDatesWithinDays(
+  workouts: readonly WorkoutRecord[],
+  asOfDate: string,
+  days: number,
+): string[] {
+  const dates = new Set<string>();
+
+  for (const workout of workouts) {
+    const ageDays = daysBetween(workout.localDate, asOfDate);
+    if (ageDays >= 0 && ageDays < days) {
+      dates.add(workout.localDate);
+    }
+  }
+
+  return [...dates].sort();
+}
+
+function totalMinutesWithinDays(
+  workouts: readonly WorkoutRecord[],
+  asOfDate: string,
+  days: number,
+): number {
+  return workouts.reduce((total, workout) => {
+    const ageDays = daysBetween(workout.localDate, asOfDate);
+
+    if (ageDays < 0 || ageDays >= days) {
+      return total;
+    }
+
+    return total + workout.elapsedSeconds / 60;
+  }, 0);
+}
+
+function longestGapDays(workouts: readonly WorkoutRecord[]): number | null {
+  const dates = [
+    ...new Set(workouts.map((workout) => workout.localDate)),
+  ].sort();
+
+  if (dates.length < 2) {
+    return null;
+  }
+
+  return dates.slice(1).reduce((longest, date, index) => {
+    const gap = daysBetween(dates[index], date);
+    return Math.max(longest, gap);
+  }, 0);
+}
+
+function hasPattern(
+  checkIns: readonly TrainingStateCheckIn[],
+  patterns: readonly RegExp[],
+): boolean {
+  return checkIns.some((checkIn) =>
+    patterns.some((pattern) => pattern.test(checkIn.text)),
+  );
+}
+
+function hasLimitedRisk(riskFlags?: RiskFlags | null): boolean {
+  if (!riskFlags) {
+    return false;
+  }
+
+  return (
+    riskFlags.has_blocking_risk ||
+    severityRank[riskFlags.highest_severity] >= severityRank.high
+  );
+}
+
+function buildClassification(
+  state: TrainingState,
+  confidence: number,
+  explanation: string,
+  recommendedBehavior: TrainingStateRecommendedBehavior,
+  activeDaysLast30: number,
+  totalWorkoutMinutesLast30: number,
+  longestGap: number | null,
+  signalsUsed: string[],
+): TrainingStateClassification {
+  const baselineBuildingRecommended =
+    recommendedBehavior === "baseline_building";
+  const recommendationConfidenceMultiplier =
+    state === "unknown" ? 0.6 : state === "currently_limited" ? 0.7 : 1;
+
+  return {
+    state,
+    confidence,
+    explanation,
+    recommendedBehavior,
+    baselineBuildingRecommended,
+    recommendationConfidenceMultiplier,
+    activeDaysLast30,
+    totalWorkoutMinutesLast30,
+    longestGapDays: longestGap,
+    signalsUsed,
+  };
+}
+
+export function classifyTrainingState(
+  input: ClassifyTrainingStateInput,
+): TrainingStateClassification {
+  const workouts = input.workouts ?? [];
+  const checkIns = input.checkIns ?? [];
+  const activeDatesLast30 = uniqueWorkoutDatesWithinDays(
+    workouts,
+    input.asOfDate,
+    30,
+  );
+  const activeDaysLast30 = activeDatesLast30.length;
+  const totalWorkoutMinutesLast30 = Math.round(
+    totalMinutesWithinDays(workouts, input.asOfDate, 30),
+  );
+  const longestGap = longestGapDays(workouts);
+  const signalsUsed: string[] = [];
+
+  if (workouts.length) {
+    signalsUsed.push("recent workouts");
+  }
+  if (checkIns.length) {
+    signalsUsed.push("check-ins");
+  }
+  if (input.riskFlags) {
+    signalsUsed.push("risk flags");
+  }
+
+  if (
+    hasLimitedRisk(input.riskFlags) ||
+    hasPattern(checkIns, limitedPatterns)
+  ) {
+    return buildClassification(
+      "currently_limited",
+      0.85,
+      "Current check-ins or risk flags indicate a limitation, so recommendations should stay conservative.",
+      "recovery_or_professional_guidance",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  if (!workouts.length && hasPattern(checkIns, firstTimePatterns)) {
+    return buildClassification(
+      "first_time_athlete",
+      0.75,
+      "The available check-in describes a first-time athlete, so baseline-building behavior is recommended.",
+      "baseline_building",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  if (!workouts.length) {
+    return buildClassification(
+      "unknown",
+      0.3,
+      "There is not enough workout or check-in data to classify the current training state.",
+      "conservative_discovery",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  if (longestGap !== null && longestGap >= 35 && activeDaysLast30 > 0) {
+    return buildClassification(
+      "returning_after_extended_gap",
+      0.8,
+      `Recent workouts resumed after an extended ${longestGap}-day training gap, so baseline-building behavior is recommended.`,
+      "baseline_building",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  if (activeDaysLast30 <= 2) {
+    return buildClassification(
+      "inconsistent_or_low_recent_activity",
+      0.7,
+      `${activeDaysLast30} active day${activeDaysLast30 === 1 ? "" : "s"} in the last 30 days indicates inconsistent or low recent activity.`,
+      "baseline_building",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  if (activeDaysLast30 >= 6 && totalWorkoutMinutesLast30 >= 360) {
+    return buildClassification(
+      "advanced_athlete",
+      0.85,
+      `${activeDaysLast30} active days and ${totalWorkoutMinutesLast30} workout minutes in the last 30 days indicate advanced recent training consistency.`,
+      "normal_progression",
+      activeDaysLast30,
+      totalWorkoutMinutesLast30,
+      longestGap,
+      signalsUsed,
+    );
+  }
+
+  return buildClassification(
+    "consistent_recreational_athlete",
+    0.75,
+    `${activeDaysLast30} active days in the last 30 days indicate consistent recreational training.`,
+    "normal_progression",
+    activeDaysLast30,
+    totalWorkoutMinutesLast30,
+    longestGap,
+    signalsUsed,
+  );
+}

--- a/src/coach/trainingState.ts
+++ b/src/coach/trainingState.ts
@@ -47,8 +47,20 @@ const firstTimePatterns = [
 ];
 
 const limitedPatterns = [
-  /\b(injur(y|ed)|pain|sick|ill|fever|limited|doctor|clinician)\b/i,
-  /\b(recovering from|can't train|cannot train)\b/i,
+  /\b(injur(y|ed)|fever|limited by|limitation(s)? from)\b/i,
+  /\b(sharp|severe|worsening|significant)\s+pain\b/i,
+  /\bpain\b.{0,32}\b(sharp|severe|worsening|significant|limiting|stopping me)\b/i,
+  /\b(sick|ill)\b.{0,32}\b(today|still|currently|now)\b/i,
+  /\b(recovering from|can't train|cannot train|not able to train|unable to train)\b/i,
+  /\b(doctor|clinician)\b.{0,40}\b(told|said|advised)\b.{0,40}\b(not to train|avoid training|stop training|rest)\b/i,
+];
+
+const nonLimitingPatterns = [
+  /\b(no|without|zero)\s+(pain|limitations?|injur(y|ies)|fever)\b/i,
+  /\bnot\s+(sick|ill|injured|limited)\b/i,
+  /\b(sick|ill|injured)\b.{0,24}\b(anymore|now gone|resolved)\b/i,
+  /\b(doctor|clinician)\b.{0,32}\b(cleared|approved|okayed|signed off)\b/i,
+  /\bcleared\s+(to train|for training|for exercise|by (my )?(doctor|clinician))\b/i,
 ];
 
 const severityRank: Record<RiskFlagSeverity, number> = {
@@ -152,6 +164,16 @@ function hasPattern(
   );
 }
 
+function hasLimitedCheckIn(checkIns: readonly TrainingStateCheckIn[]): boolean {
+  return checkIns.some((checkIn) => {
+    if (nonLimitingPatterns.some((pattern) => pattern.test(checkIn.text))) {
+      return false;
+    }
+
+    return limitedPatterns.some((pattern) => pattern.test(checkIn.text));
+  });
+}
+
 function hasLimitedRisk(riskFlags?: RiskFlags | null): boolean {
   if (!riskFlags) {
     return false;
@@ -223,10 +245,7 @@ export function classifyTrainingState(
     signalsUsed.push("risk flags");
   }
 
-  if (
-    hasLimitedRisk(input.riskFlags) ||
-    hasPattern(checkIns, limitedPatterns)
-  ) {
+  if (hasLimitedRisk(input.riskFlags) || hasLimitedCheckIn(checkIns)) {
     return buildClassification(
       "currently_limited",
       0.85,

--- a/src/coach/trainingState.ts
+++ b/src/coach/trainingState.ts
@@ -118,6 +118,31 @@ function longestGapDays(workouts: readonly WorkoutRecord[]): number | null {
   }, 0);
 }
 
+function gapBeforeRecentBlockDays(
+  workouts: readonly WorkoutRecord[],
+  recentDates: readonly string[],
+): number | null {
+  if (!recentDates.length) {
+    return null;
+  }
+
+  const recentBlockStart = recentDates[0];
+  const previousDates = [
+    ...new Set(
+      workouts
+        .map((workout) => workout.localDate)
+        .filter((date) => date < recentBlockStart),
+    ),
+  ].sort();
+  const previousDate = previousDates[previousDates.length - 1];
+
+  if (!previousDate) {
+    return null;
+  }
+
+  return daysBetween(previousDate, recentBlockStart);
+}
+
 function hasPattern(
   checkIns: readonly TrainingStateCheckIn[],
   patterns: readonly RegExp[],
@@ -182,6 +207,10 @@ export function classifyTrainingState(
     totalMinutesWithinDays(workouts, input.asOfDate, 30),
   );
   const longestGap = longestGapDays(workouts);
+  const gapBeforeRecentBlock = gapBeforeRecentBlockDays(
+    workouts,
+    activeDatesLast30,
+  );
   const signalsUsed: string[] = [];
 
   if (workouts.length) {
@@ -236,11 +265,15 @@ export function classifyTrainingState(
     );
   }
 
-  if (longestGap !== null && longestGap >= 35 && activeDaysLast30 > 0) {
+  if (
+    gapBeforeRecentBlock !== null &&
+    gapBeforeRecentBlock >= 35 &&
+    activeDaysLast30 <= 2
+  ) {
     return buildClassification(
       "returning_after_extended_gap",
       0.8,
-      `Recent workouts resumed after an extended ${longestGap}-day training gap, so baseline-building behavior is recommended.`,
+      `Recent workouts resumed after an extended ${gapBeforeRecentBlock}-day training gap, so baseline-building behavior is recommended.`,
       "baseline_building",
       activeDaysLast30,
       totalWorkoutMinutesLast30,


### PR DESCRIPTION
## Summary
- add deterministic training state classification for Track B coach logic
- cover unknown, first-time, returning, low activity, recreational, advanced, and limited states
- add regression coverage for historical gaps and negated/non-limiting check-ins

## Verification
- npm test -- --runInBand src/coach/trainingState.test.ts
- npm run typecheck
- git diff --check origin/main..HEAD

Fixes #15