### PR TITLE
[codex] Use saved athlete name in greetings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -85,6 +85,7 @@ export default function App() {
   const [lastSuccessfulSync, setLastSuccessfulSync] = useState<LastSync>(null);
   const [recentSyncRuns, setRecentSyncRuns] = useState<SyncRuns>([]);
   const [appSettings, setAppSettings] = useState<AppSettings>(emptyAppSettings);
+  const [athleteNameDraft, setAthleteNameDraft] = useState("");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [coachDraft, setCoachDraft] = useState("");
   const [coachMessages, setCoachMessages] = useState<
@@ -147,6 +148,7 @@ export default function App() {
       .then(async () => {
         const nextSettings = await loadAppSettings();
         setAppSettings(nextSettings);
+        setAthleteNameDraft(nextSettings.athleteName ?? "");
         setRangeDays(nextSettings.defaultSyncRangeDays);
         refreshStoreInBackground();
       })
@@ -200,6 +202,26 @@ export default function App() {
       setAppSettings(nextSettings);
       setApiKeyDraft("");
       setStatus("OpenAI API key cleared");
+    } catch (error) {
+      setStatus(String(error instanceof Error ? error.message : error));
+    } finally {
+      setSettingsBusy(false);
+    }
+  }
+
+  async function saveAthleteName() {
+    setSettingsBusy(true);
+    try {
+      const nextSettings = await saveAppSettings({
+        athleteName: athleteNameDraft,
+      });
+      setAppSettings(nextSettings);
+      setAthleteNameDraft(nextSettings.athleteName ?? "");
+      setStatus(
+        nextSettings.athleteName
+          ? "Preferred name saved locally"
+          : "Preferred name cleared",
+      );
     } catch (error) {
       setStatus(String(error instanceof Error ? error.message : error));
     } finally {
@@ -562,6 +584,7 @@ export default function App() {
         ) : null}
         {entryMode === "onboarding" ? (
           <CoachOnboardingScreen
+            athleteName={appSettings.athleteName}
             busy={busy}
             canSync={canSync}
             onDiscussGoal={discussOnboardingGoal}
@@ -582,6 +605,7 @@ export default function App() {
         ) : null}
         {entryMode === "app" && activeTab === "coach" ? (
           <CoachScreen
+            athleteName={appSettings.athleteName}
             busy={busy}
             coachBusy={coachBusy}
             coachDraft={coachDraft}
@@ -608,6 +632,7 @@ export default function App() {
           <SourceScreen
             apiKeyDraft={apiKeyDraft}
             appSettings={appSettings}
+            athleteNameDraft={athleteNameDraft}
             busy={busy}
             lastSync={lastSync}
             lastSuccessfulSync={lastSuccessfulSync}
@@ -616,11 +641,13 @@ export default function App() {
             onExport={runExport}
             onIncrementalSync={() => void runSync("incremental")}
             onSaveApiKey={saveApiKey}
+            onSaveAthleteName={saveAthleteName}
             onSetDefaultRange={setDefaultSyncRange}
             onSync={runSync}
             rangeDays={rangeDays}
             recentSyncRuns={recentSyncRuns}
             setApiKeyDraft={setApiKeyDraft}
+            setAthleteNameDraft={setAthleteNameDraft}
             setRangeDays={setRangeDays}
             settingsBusy={settingsBusy}
             snapshot={snapshot}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -18,6 +18,7 @@ export const ranges = [7, 30, 365];
 export const baselineRangeDays = 365;
 
 export const emptyAppSettings: AppSettings = {
+  athleteName: null,
   hasOpenAiApiKey: false,
   openAiApiKeySource: null,
   defaultSyncRangeDays: baselineRangeDays,

--- a/src/screens/CoachOnboardingScreen.tsx
+++ b/src/screens/CoachOnboardingScreen.tsx
@@ -45,6 +45,7 @@ import {
 } from "../ui/primitives";
 
 export function CoachOnboardingScreen({
+  athleteName,
   busy,
   canSync,
   onDiscussGoal,
@@ -55,6 +56,7 @@ export function CoachOnboardingScreen({
   status,
   snapshot,
 }: {
+  athleteName?: string | null;
   busy: boolean;
   canSync: boolean;
   onDiscussGoal: (request: {
@@ -92,9 +94,9 @@ export function CoachOnboardingScreen({
     constraints: "",
     summary: "",
   });
-  const athleteName: string | undefined = undefined;
-  const welcomeLine = athleteName
-    ? `Hello ${athleteName}, welcome to BioStream.`
+  const displayName = athleteName?.trim() || null;
+  const welcomeLine = displayName
+    ? `Hello ${displayName}, welcome to BioStream.`
     : "Hello, welcome to BioStream.";
   const connectLabel = `Connect ${sourceLabel}`;
   const dataActionLabel = canSync

--- a/src/screens/CoachScreen.test.tsx
+++ b/src/screens/CoachScreen.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react-native";
+
+import { emptySnapshot } from "../core/constants";
+import type { CoachConversationMessage, LastSync } from "../core/types";
+import { CoachScreen } from "./CoachScreen";
+
+const baseProps = {
+  busy: false,
+  coachBusy: false,
+  coachDraft: "",
+  coachMessages: [] as CoachConversationMessage[],
+  goalText: "",
+  hasOpenAiApiKey: false,
+  lastSync: null as LastSync,
+  onChangeCoachDraft: jest.fn(),
+  onOpenWorkout: jest.fn(),
+  onSendCoachMessage: jest.fn(),
+  onSync: jest.fn(),
+  snapshot: emptySnapshot,
+  status: "Ready",
+  warnings: [] as string[],
+};
+
+describe("CoachScreen athlete greeting", () => {
+  it("does not fall back to a hardcoded athlete name", () => {
+    render(<CoachScreen {...baseProps} athleteName={undefined} />);
+
+    expect(screen.queryByText(/Martin/i)).toBeNull();
+    expect(screen.getByText("Good morning.")).toBeOnTheScreen();
+  });
+
+  it("uses the supplied athlete name when one is available", () => {
+    render(<CoachScreen {...baseProps} athleteName="Sam" />);
+
+    expect(screen.getByText("Good morning, Sam.")).toBeOnTheScreen();
+    expect(screen.queryByText(/Martin/i)).toBeNull();
+  });
+});

--- a/src/screens/CoachScreen.tsx
+++ b/src/screens/CoachScreen.tsx
@@ -53,6 +53,7 @@ function coachGoalPhrase(goalText: string): string {
 }
 
 export function CoachScreen({
+  athleteName,
   coachBusy,
   coachDraft,
   coachMessages,
@@ -68,6 +69,7 @@ export function CoachScreen({
   onSync,
   onOpenWorkout,
 }: {
+  athleteName?: string | null;
   coachBusy: boolean;
   coachDraft: string;
   coachMessages: CoachConversationMessage[];
@@ -99,7 +101,7 @@ export function CoachScreen({
     : "—";
   const hrvLabel = hrvMetricLabel(current);
   const rhr = current?.restingHr ? `${Math.round(current.restingHr)} bpm` : "—";
-  const athleteName = "Martin";
+  const displayName = athleteName?.trim() || null;
   const goalPhrase = coachGoalPhrase(goalText);
   const wearableLabel =
     Platform.OS === "ios"
@@ -141,9 +143,12 @@ export function CoachScreen({
     snapshot.nutritionDays > 0 ||
     snapshot.coverageDays > 0;
   const loadingInitialMetrics = busy && !hasSyncedData;
-  const coachGreeting = hasSyncedData
-    ? `Good morning ${athleteName}. You are in a good spot to keep building toward ${goalPhrase}. I have checked the recovery picture and lined up today's work. If anything has changed since the data came in, tell me and I will adjust it.`
-    : `Good morning ${athleteName}. Let's keep building toward ${goalPhrase}. I do not have enough wearable history yet, so I will keep things sensible and adjust as you give me more context.`;
+  const coachHeroTitle = displayName
+    ? `Good morning, ${displayName}.`
+    : "Good morning.";
+  const coachHeroText = hasSyncedData
+    ? `You are in a good spot to keep building toward ${goalPhrase}. I have checked the recovery picture and lined up today's work. If anything has changed since the data came in, tell me and I will adjust it.`
+    : `Let's keep building toward ${goalPhrase}. I do not have enough wearable history yet, so I will keep things sensible and adjust as you give me more context.`;
   const feedRef = useRef<ScrollView | null>(null);
 
   function scrollFeedToEnd(animated = true) {
@@ -187,12 +192,8 @@ export function CoachScreen({
         <View style={styles.coachHero}>
           <View style={styles.coachHeroTop}>
             <View style={{ flex: 1 }}>
-              <Text style={styles.coachHeroTitle}>
-                Good morning, {athleteName}.
-              </Text>
-              <Text style={styles.coachHeroText}>
-                {coachGreeting.replace(`Good morning ${athleteName}. `, "")}
-              </Text>
+              <Text style={styles.coachHeroTitle}>{coachHeroTitle}</Text>
+              <Text style={styles.coachHeroText}>{coachHeroText}</Text>
             </View>
             <View style={styles.coachHeroBadge}>
               <Text style={styles.coachHeroBadgeText}>

--- a/src/screens/SourceScreen.tsx
+++ b/src/screens/SourceScreen.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   TextInput,
   View,
-} from 'react-native';
+} from "react-native";
 import {
   Activity,
   ChartColumn,
@@ -22,31 +22,37 @@ import {
   Settings,
   Shield,
   Trash2,
+  User,
   Zap,
   type LucideIcon,
-} from 'lucide-react-native';
+} from "lucide-react-native";
 
-import { ranges } from '../core/constants';
-import { dataAge, formatDateKey, formatNumber, metricLabel } from '../core/formatters';
-import { availabilityForTypes } from '../core/metricAvailability';
-import type { LastSync, SyncRuns } from '../core/types';
+import { ranges } from "../core/constants";
+import {
+  dataAge,
+  formatDateKey,
+  formatNumber,
+  metricLabel,
+} from "../core/formatters";
+import { availabilityForTypes } from "../core/metricAvailability";
+import type { LastSync, SyncRuns } from "../core/types";
 import {
   currentHealthProviderLabel,
   openCurrentPlatformHealthSettings,
-} from '../health/syncPipeline';
+} from "../health/syncPipeline";
 import type {
   CanonicalType,
   DailyMetrics,
   HealthConnectReadDiagnostic,
   PipelineSnapshot,
   SourceFreshness,
-} from '../health/types';
-import { formatRange, formatShortDateTime } from '../lib/dates';
-import type { AppSettings } from '../storage/appSettings';
-import { styles } from '../styles/appStyles';
-import { tokens } from '../theme/tokens';
-import { AppButton, SectionLabel } from '../ui/primitives';
-import { AnalyticsPanel } from './AnalyticsScreen';
+} from "../health/types";
+import { formatRange, formatShortDateTime } from "../lib/dates";
+import type { AppSettings } from "../storage/appSettings";
+import { styles } from "../styles/appStyles";
+import { tokens } from "../theme/tokens";
+import { AppButton, SectionLabel } from "../ui/primitives";
+import { AnalyticsPanel } from "./AnalyticsScreen";
 
 function PermissionRow({
   icon: Icon,
@@ -68,7 +74,9 @@ function PermissionRow({
       </View>
       <View style={[styles.toggle, active && styles.toggleActive]}>
         <View style={[styles.toggleKnob, active && styles.toggleKnobActive]}>
-          {active ? <Check color={tokens.accent} size={11} strokeWidth={3} /> : null}
+          {active ? (
+            <Check color={tokens.accent} size={11} strokeWidth={3} />
+          ) : null}
         </View>
       </View>
     </View>
@@ -76,57 +84,80 @@ function PermissionRow({
 }
 
 function diagnosticTitle(diagnostic: HealthConnectReadDiagnostic): string {
-  const kind = diagnostic.readKind === 'aggregate' ? 'daily' : 'records';
+  const kind = diagnostic.readKind === "aggregate" ? "daily" : "records";
   return `${metricLabel(diagnostic.canonicalType)} · ${kind}`;
 }
 
 function diagnosticDetail(diagnostic: HealthConnectReadDiagnostic): string {
   const permission =
-    diagnostic.permission === 'granted' ? 'Permission granted' : 'Permission missing';
+    diagnostic.permission === "granted"
+      ? "Permission granted"
+      : "Permission missing";
   const counts = `${diagnostic.recordsRead} read · ${diagnostic.samplesWritten} saved`;
-  return diagnostic.message ? `${permission} · ${counts} · ${diagnostic.message}` : `${permission} · ${counts}`;
+  return diagnostic.message
+    ? `${permission} · ${counts} · ${diagnostic.message}`
+    : `${permission} · ${counts}`;
 }
 
-function DiagnosticRow({ diagnostic }: { diagnostic: HealthConnectReadDiagnostic }) {
-  const active = diagnostic.permission === 'granted' && diagnostic.samplesWritten > 0;
+function DiagnosticRow({
+  diagnostic,
+}: {
+  diagnostic: HealthConnectReadDiagnostic;
+}) {
+  const active =
+    diagnostic.permission === "granted" && diagnostic.samplesWritten > 0;
 
   return (
     <View style={styles.diagnosticRow}>
-      <View style={[styles.diagnosticDot, active && styles.diagnosticDotActive]} />
+      <View
+        style={[styles.diagnosticDot, active && styles.diagnosticDotActive]}
+      />
       <View style={styles.diagnosticCopy}>
-        <Text style={styles.diagnosticTitle}>{diagnosticTitle(diagnostic)}</Text>
-        <Text style={styles.diagnosticDetail}>{diagnosticDetail(diagnostic)}</Text>
+        <Text style={styles.diagnosticTitle}>
+          {diagnosticTitle(diagnostic)}
+        </Text>
+        <Text style={styles.diagnosticDetail}>
+          {diagnosticDetail(diagnostic)}
+        </Text>
       </View>
     </View>
   );
 }
 
-function freshnessStateLabel(state: SourceFreshness['state']): string {
-  if (state === 'fresh') return 'Fresh';
-  if (state === 'partial') return 'Partial';
-  if (state === 'stale') return 'Stale';
-  return 'Missing';
+function freshnessStateLabel(state: SourceFreshness["state"]): string {
+  if (state === "fresh") return "Fresh";
+  if (state === "partial") return "Partial";
+  if (state === "stale") return "Stale";
+  return "Missing";
 }
 
-function freshnessBadgeStyle(state: SourceFreshness['state']) {
-  if (state === 'fresh') return styles.scoreBadge_live;
-  if (state === 'partial') return styles.scoreBadge_permission;
-  if (state === 'stale') return styles.scoreBadge_empty;
+function freshnessBadgeStyle(state: SourceFreshness["state"]) {
+  if (state === "fresh") return styles.scoreBadge_live;
+  if (state === "partial") return styles.scoreBadge_permission;
+  if (state === "stale") return styles.scoreBadge_empty;
   return styles.scoreBadge_unchecked;
 }
 
 function SourceFreshnessRow({ source }: { source: SourceFreshness }) {
-  const active = source.state === 'fresh' || source.state === 'partial';
+  const active = source.state === "fresh" || source.state === "partial";
   const detailParts = [
-    source.latestLocalDate ? `Latest ${formatDateKey(source.latestLocalDate)}` : null,
-    source.lastUpdatedAt ? `Updated ${formatShortDateTime(source.lastUpdatedAt)}` : null,
+    source.latestLocalDate
+      ? `Latest ${formatDateKey(source.latestLocalDate)}`
+      : null,
+    source.lastUpdatedAt
+      ? `Updated ${formatShortDateTime(source.lastUpdatedAt)}`
+      : null,
     source.sampleCount ? `${formatNumber(source.sampleCount)} rows` : null,
   ].filter(Boolean);
-  const detail = [...detailParts, ...source.limitations].join(' · ') || 'No status detail available';
+  const detail =
+    [...detailParts, ...source.limitations].join(" · ") ||
+    "No status detail available";
 
   return (
     <View style={styles.diagnosticRow}>
-      <View style={[styles.diagnosticDot, active && styles.diagnosticDotActive]} />
+      <View
+        style={[styles.diagnosticDot, active && styles.diagnosticDotActive]}
+      />
       <View style={styles.diagnosticCopy}>
         <View style={styles.scoreTitleLine}>
           <Text style={styles.diagnosticTitle}>{source.label}</Text>
@@ -141,12 +172,12 @@ function SourceFreshnessRow({ source }: { source: SourceFreshness }) {
 }
 
 function providerName(provider: string): string {
-  if (provider === 'healthkit') {
-    return 'Apple Health';
+  if (provider === "healthkit") {
+    return "Apple Health";
   }
 
-  if (provider === 'health_connect') {
-    return 'Health Connect';
+  if (provider === "health_connect") {
+    return "Health Connect";
   }
 
   return provider;
@@ -160,10 +191,10 @@ function syncRunRangeLabel(run: NonNullable<LastSync>): string {
 }
 
 function SyncRunHistoryRow({ run }: { run: SyncRuns[number] }) {
-  const statusOk = run.status === 'ok';
+  const statusOk = run.status === "ok";
   const detailParts = [
     providerName(run.provider),
-    run.sync_type === 'incremental' ? 'Incremental' : 'Manual',
+    run.sync_type === "incremental" ? "Incremental" : "Manual",
     syncRunRangeLabel(run),
   ];
   const countParts = [
@@ -178,21 +209,30 @@ function SyncRunHistoryRow({ run }: { run: SyncRuns[number] }) {
     <View style={styles.syncRunRow}>
       <View style={styles.syncRunTopLine}>
         <View style={styles.syncRunTitleWrap}>
-          <Text style={styles.syncRunTitle}>{formatShortDateTime(run.started_at)}</Text>
-          <Text style={styles.syncRunDetail}>{detailParts.join(' · ')}</Text>
+          <Text style={styles.syncRunTitle}>
+            {formatShortDateTime(run.started_at)}
+          </Text>
+          <Text style={styles.syncRunDetail}>{detailParts.join(" · ")}</Text>
         </View>
-        <View style={[styles.syncRunBadge, statusOk ? styles.syncRunBadgeOk : styles.syncRunBadgeError]}>
+        <View
+          style={[
+            styles.syncRunBadge,
+            statusOk ? styles.syncRunBadgeOk : styles.syncRunBadgeError,
+          ]}
+        >
           <Text
             style={[
               styles.syncRunBadgeText,
-              statusOk ? styles.syncRunBadgeTextOk : styles.syncRunBadgeTextError,
+              statusOk
+                ? styles.syncRunBadgeTextOk
+                : styles.syncRunBadgeTextError,
             ]}
           >
-            {statusOk ? 'OK' : 'Error'}
+            {statusOk ? "OK" : "Error"}
           </Text>
         </View>
       </View>
-      <Text style={styles.syncRunCounts}>{countParts.join(' · ')}</Text>
+      <Text style={styles.syncRunCounts}>{countParts.join(" · ")}</Text>
       {run.warning_count || run.diagnostic_count ? (
         <Text style={styles.syncRunDetail}>
           {`${run.warning_count.toLocaleString()} warnings · ${run.diagnostic_count.toLocaleString()} diagnostics`}
@@ -219,11 +259,13 @@ export function SourceScreen({
   lastSuccessfulSync,
   recentSyncRuns,
   appSettings,
+  athleteNameDraft,
   apiKeyDraft,
   settingsBusy,
   busy,
   status,
   rangeDays,
+  setAthleteNameDraft,
   setRangeDays,
   setApiKeyDraft,
   onSync,
@@ -231,6 +273,7 @@ export function SourceScreen({
   onExport,
   onClear,
   onSaveApiKey,
+  onSaveAthleteName,
   onClearApiKey,
   onSetDefaultRange,
 }: {
@@ -239,11 +282,13 @@ export function SourceScreen({
   lastSuccessfulSync: LastSync;
   recentSyncRuns: SyncRuns;
   appSettings: AppSettings;
+  athleteNameDraft: string;
   apiKeyDraft: string;
   settingsBusy: boolean;
   busy: boolean;
   status: string;
   rangeDays: number;
+  setAthleteNameDraft: (value: string) => void;
   setRangeDays: (value: number) => void;
   setApiKeyDraft: (value: string) => void;
   onSync: () => void;
@@ -251,31 +296,40 @@ export function SourceScreen({
   onExport: () => void;
   onClear: () => void;
   onSaveApiKey: () => void;
+  onSaveAthleteName: () => void;
   onClearApiKey: () => void;
   onSetDefaultRange: (value: number) => void;
 }) {
   const sourceLabel = currentHealthProviderLabel();
-  const canRunNativeSync = Platform.OS === 'ios' || Platform.OS === 'android';
-  const displaySourceLabel = canRunNativeSync ? sourceLabel : 'Web preview';
-  const pipelineTitle = canRunNativeSync ? 'Local health pipeline' : 'Browser demo dataset';
+  const canRunNativeSync = Platform.OS === "ios" || Platform.OS === "android";
+  const displaySourceLabel = canRunNativeSync ? sourceLabel : "Web preview";
+  const pipelineTitle = canRunNativeSync
+    ? "Local health pipeline"
+    : "Browser demo dataset";
   const pipelineText = canRunNativeSync
     ? `Reads ${sourceLabel} records into schema tables, then derives the coaching surface from daily rollups. Nothing leaves the device from this app.`
-    : 'The web preview uses a local mock PipelineSnapshot so the demo can run in the browser. Real Apple Health or Health Connect sync requires a native mobile build.';
+    : "The web preview uses a local mock PipelineSnapshot so the demo can run in the browser. Real Apple Health or Health Connect sync requires a native mobile build.";
   const apiKeyStatus =
-    appSettings.openAiApiKeySource === 'secure_store'
-      ? 'Saved on this device'
-      : appSettings.openAiApiKeySource === 'local_storage'
-        ? 'Saved in browser local storage'
-      : appSettings.openAiApiKeySource === 'embedded'
-        ? 'Using bundled demo key'
-        : 'Not saved';
-  const apiKeyPlaceholder = appSettings.hasOpenAiApiKey ? 'Replace active key' : 'sk-...';
+    appSettings.openAiApiKeySource === "secure_store"
+      ? "Saved on this device"
+      : appSettings.openAiApiKeySource === "local_storage"
+        ? "Saved in browser local storage"
+        : appSettings.openAiApiKeySource === "embedded"
+          ? "Using bundled demo key"
+          : "Not saved";
+  const apiKeyPlaceholder = appSettings.hasOpenAiApiKey
+    ? "Replace active key"
+    : "sk-...";
+  const normalizedAthleteNameDraft = athleteNameDraft.trim();
+  const savedAthleteName = appSettings.athleteName ?? "";
+  const athleteNameStatus = savedAthleteName || "Not set";
+  const athleteNameUnchanged = normalizedAthleteNameDraft === savedAthleteName;
   const diagnosticFocus: CanonicalType[] = [
-    'sleep_session',
-    'resting_heart_rate',
-    'hrv_rmssd',
-    'hrv_sdnn',
-    'heart_rate',
+    "sleep_session",
+    "resting_heart_rate",
+    "hrv_rmssd",
+    "hrv_sdnn",
+    "heart_rate",
   ];
   const focusedDiagnostics = snapshot.latestDiagnostics.filter((diagnostic) =>
     diagnosticFocus.includes(diagnostic.canonicalType),
@@ -289,8 +343,8 @@ export function SourceScreen({
   const hasSleepSignal =
     snapshot.sleepCount > 0 ||
     hasHistory((day) => day.sleepSeconds != null) ||
-    hasSamples(['sleep_session']) ||
-    hasAvailability(['sleep_session']);
+    hasSamples(["sleep_session"]) ||
+    hasAvailability(["sleep_session"]);
   const hasVitalsSignal =
     hasHistory(
       (day) =>
@@ -299,17 +353,32 @@ export function SourceScreen({
         day.hrvLastNightAvg != null ||
         day.vo2max != null,
     ) ||
-    hasSamples(['heart_rate', 'resting_heart_rate', 'hrv_rmssd', 'hrv_sdnn', 'vo2max']) ||
-    hasAvailability(['heart_rate', 'resting_heart_rate', 'hrv_rmssd', 'hrv_sdnn', 'vo2max']);
-  const hasWorkoutSignal = snapshot.workoutCount > 0 || hasAvailability(['workout']);
+    hasSamples([
+      "heart_rate",
+      "resting_heart_rate",
+      "hrv_rmssd",
+      "hrv_sdnn",
+      "vo2max",
+    ]) ||
+    hasAvailability([
+      "heart_rate",
+      "resting_heart_rate",
+      "hrv_rmssd",
+      "hrv_sdnn",
+      "vo2max",
+    ]);
+  const hasWorkoutSignal =
+    snapshot.workoutCount > 0 || hasAvailability(["workout"]);
   const hasActivitySignal =
-    hasHistory((day) => day.hasSteps || day.hasEnergy || day.distanceKm != null) ||
-    hasSamples(['steps', 'active_energy', 'total_energy', 'distance']) ||
-    hasAvailability(['steps', 'active_energy', 'total_energy', 'distance']);
+    hasHistory(
+      (day) => day.hasSteps || day.hasEnergy || day.distanceKm != null,
+    ) ||
+    hasSamples(["steps", "active_energy", "total_energy", "distance"]) ||
+    hasAvailability(["steps", "active_energy", "total_energy", "distance"]);
   const hasNutritionSignal =
     snapshot.nutritionDays > 0 ||
-    hasSamples(['nutrition', 'hydration']) ||
-    hasAvailability(['nutrition', 'hydration']);
+    hasSamples(["nutrition", "hydration"]) ||
+    hasAvailability(["nutrition", "hydration"]);
   const hasBodySignal =
     hasHistory(
       (day) =>
@@ -317,8 +386,8 @@ export function SourceScreen({
         day.bodyFatPct != null ||
         day.leanBodyMassKg != null,
     ) ||
-    hasSamples(['weight', 'body_fat', 'lean_body_mass']) ||
-    hasAvailability(['weight', 'body_fat', 'lean_body_mass']);
+    hasSamples(["weight", "body_fat", "lean_body_mass"]) ||
+    hasAvailability(["weight", "body_fat", "lean_body_mass"]);
 
   return (
     <View style={styles.screen}>
@@ -327,7 +396,10 @@ export function SourceScreen({
         <Text style={styles.pageTitle}>{displaySourceLabel}</Text>
       </View>
 
-      <ScrollView contentContainerStyle={styles.pageContent} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={styles.pageContent}
+        showsVerticalScrollIndicator={false}
+      >
         <View style={styles.connectCard}>
           <View style={styles.connectIcon}>
             {busy ? (
@@ -349,7 +421,10 @@ export function SourceScreen({
               accessibilityRole="button"
               key={days}
               onPress={() => setRangeDays(days)}
-              style={[styles.rangeButton, days === rangeDays && styles.rangeButtonActive]}
+              style={[
+                styles.rangeButton,
+                days === rangeDays && styles.rangeButtonActive,
+              ]}
             >
               <Text
                 style={[
@@ -367,7 +442,9 @@ export function SourceScreen({
           <AppButton
             disabled={busy || !canRunNativeSync}
             icon={RefreshCw}
-            label={busy ? 'Syncing' : canRunNativeSync ? 'Sync' : 'Mobile sync only'}
+            label={
+              busy ? "Syncing" : canRunNativeSync ? "Sync" : "Mobile sync only"
+            }
             onPress={onSync}
             variant="primary"
           />
@@ -387,14 +464,19 @@ export function SourceScreen({
           />
         </View>
         <View style={styles.actionsRow}>
-          {Platform.OS === 'android' ? (
+          {Platform.OS === "android" ? (
             <AppButton
               disabled={busy}
               icon={Settings}
               label="Permissions"
-              onPress={() => void openCurrentPlatformHealthSettings().catch((error) => {
-                Alert.alert('Health settings', String(error instanceof Error ? error.message : error));
-              })}
+              onPress={() =>
+                void openCurrentPlatformHealthSettings().catch((error) => {
+                  Alert.alert(
+                    "Health settings",
+                    String(error instanceof Error ? error.message : error),
+                  );
+                })
+              }
             />
           ) : null}
           <AppButton
@@ -423,6 +505,34 @@ export function SourceScreen({
         <View style={styles.settingsCard}>
           <View style={styles.settingsHeader}>
             <View style={styles.settingsIcon}>
+              <User color={tokens.accent} size={18} strokeWidth={2} />
+            </View>
+            <View style={styles.settingsCopy}>
+              <Text style={styles.settingsTitle}>Preferred name</Text>
+              <Text style={styles.settingsMeta}>{athleteNameStatus}</Text>
+            </View>
+          </View>
+          <TextInput
+            autoCapitalize="words"
+            autoCorrect={false}
+            onChangeText={setAthleteNameDraft}
+            placeholder="Name"
+            placeholderTextColor={tokens.muted}
+            style={styles.apiKeyInput}
+            value={athleteNameDraft}
+          />
+          <View style={styles.actionsRow}>
+            <AppButton
+              disabled={settingsBusy || athleteNameUnchanged}
+              icon={Check}
+              label="Save name"
+              onPress={onSaveAthleteName}
+            />
+          </View>
+
+          <View style={styles.settingDivider} />
+          <View style={styles.settingsHeader}>
+            <View style={styles.settingsIcon}>
               <Lock color={tokens.accent} size={18} strokeWidth={2} />
             </View>
             <View style={styles.settingsCopy}>
@@ -444,7 +554,7 @@ export function SourceScreen({
             <AppButton
               disabled={settingsBusy || !apiKeyDraft.trim()}
               icon={Check}
-              label={appSettings.hasOpenAiApiKey ? 'Replace' : 'Save'}
+              label={appSettings.hasOpenAiApiKey ? "Replace" : "Save"}
               onPress={onSaveApiKey}
             />
             <AppButton
@@ -460,7 +570,9 @@ export function SourceScreen({
           <View style={styles.settingRow}>
             <View style={styles.settingsCopy}>
               <Text style={styles.settingsTitle}>Default sync range</Text>
-              <Text style={styles.settingsMeta}>{appSettings.defaultSyncRangeDays} days</Text>
+              <Text style={styles.settingsMeta}>
+                {appSettings.defaultSyncRangeDays} days
+              </Text>
             </View>
             <View style={styles.settingSegments}>
               {ranges.map((days) => (
@@ -471,7 +583,8 @@ export function SourceScreen({
                   onPress={() => onSetDefaultRange(days)}
                   style={[
                     styles.settingSegment,
-                    appSettings.defaultSyncRangeDays === days && styles.settingSegmentActive,
+                    appSettings.defaultSyncRangeDays === days &&
+                      styles.settingSegmentActive,
                   ]}
                 >
                   <Text
@@ -496,7 +609,9 @@ export function SourceScreen({
               <SourceFreshnessRow key={source.domain} source={source} />
             ))
           ) : (
-            <Text style={styles.emptyText}>Run a sync to derive source freshness.</Text>
+            <Text style={styles.emptyText}>
+              Run a sync to derive source freshness.
+            </Text>
           )}
         </View>
 
@@ -550,17 +665,19 @@ export function SourceScreen({
               />
             ))
           ) : (
-            <Text style={styles.emptyText}>Run a sync to see sleep and vitals read results.</Text>
+            <Text style={styles.emptyText}>
+              Run a sync to see sleep and vitals read results.
+            </Text>
           )}
         </View>
 
         <View style={styles.privacyCard}>
           <Lock color={tokens.muted} size={16} strokeWidth={2} />
           <Text style={styles.privacyText}>
-            {snapshot.trainingLoad.summary}{' '}
-            Vendor-only metrics such as stress, body battery, sleep score, and
-            training load are preserved only when a source writes them. They are not
-            fabricated from generic platform data.
+            {snapshot.trainingLoad.summary} Vendor-only metrics such as stress,
+            body battery, sleep score, and training load are preserved only when
+            a source writes them. They are not fabricated from generic platform
+            data.
           </Text>
         </View>
       </ScrollView>

--- a/src/storage/appSettings.ts
+++ b/src/storage/appSettings.ts
@@ -1,32 +1,41 @@
-import * as SecureStore from 'expo-secure-store';
+import * as SecureStore from "expo-secure-store";
 
-import { resolveOpenAiApiKey } from '../config/openAiKeyFallback';
-import type { OpenAiApiKeySource } from '../config/openAiKeyFallback';
-import { localOpenAiApiKey } from '../config/localOpenAiApiKey.generated';
+import { resolveOpenAiApiKey } from "../config/openAiKeyFallback";
+import type { OpenAiApiKeySource } from "../config/openAiKeyFallback";
+import { localOpenAiApiKey } from "../config/localOpenAiApiKey.generated";
 
 export type AppSettings = {
   hasOpenAiApiKey: boolean;
   openAiApiKeySource: OpenAiApiKeySource;
   defaultSyncRangeDays: number;
+  athleteName: string | null;
 };
 
 type StoredAppSettings = {
   defaultSyncRangeDays?: number;
+  athleteName?: string | null;
 };
 
-const openAiApiKeyStorageKey = 'biostream.openai_api_key';
-const appSettingsStorageKey = 'biostream.local_settings';
+const openAiApiKeyStorageKey = "biostream.openai_api_key";
+const appSettingsStorageKey = "biostream.local_settings";
 const fallbackSettings: StoredAppSettings = {
   defaultSyncRangeDays: 365,
 };
 const allowedSyncRanges = new Set([7, 30, 365]);
 
 function normalizeSettings(settings: StoredAppSettings): StoredAppSettings {
-  const defaultSyncRangeDays = allowedSyncRanges.has(Number(settings.defaultSyncRangeDays))
+  const defaultSyncRangeDays = allowedSyncRanges.has(
+    Number(settings.defaultSyncRangeDays),
+  )
     ? Number(settings.defaultSyncRangeDays)
     : fallbackSettings.defaultSyncRangeDays;
+  const athleteName =
+    typeof settings.athleteName === "string" && settings.athleteName.trim()
+      ? settings.athleteName.trim().slice(0, 80)
+      : null;
 
   return {
+    athleteName,
     defaultSyncRangeDays,
   };
 }
@@ -51,18 +60,21 @@ export async function loadAppSettings(): Promise<AppSettings> {
   ]);
   const activeApiKey = resolveOpenAiApiKey({
     storedApiKey: apiKey,
-    storedSource: 'secure_store',
+    storedSource: "secure_store",
     embeddedApiKey: localOpenAiApiKey,
   });
 
   return {
+    athleteName: settings.athleteName ?? null,
     hasOpenAiApiKey: Boolean(activeApiKey.apiKey),
     openAiApiKeySource: activeApiKey.source,
     defaultSyncRangeDays: settings.defaultSyncRangeDays ?? 365,
   };
 }
 
-export async function saveAppSettings(settings: Partial<StoredAppSettings>): Promise<AppSettings> {
+export async function saveAppSettings(
+  settings: Partial<StoredAppSettings>,
+): Promise<AppSettings> {
   const current = await loadStoredSettings();
   const next = normalizeSettings({
     ...current,
@@ -76,7 +88,7 @@ export async function saveAppSettings(settings: Partial<StoredAppSettings>): Pro
 export async function saveOpenAiApiKey(apiKey: string): Promise<AppSettings> {
   const trimmed = apiKey.trim();
   if (!trimmed) {
-    throw new Error('Enter an API key before saving.');
+    throw new Error("Enter an API key before saving.");
   }
 
   await SecureStore.setItemAsync(openAiApiKeyStorageKey, trimmed);
@@ -92,7 +104,7 @@ export async function readOpenAiApiKey(): Promise<string | null> {
   const apiKey = await SecureStore.getItemAsync(openAiApiKeyStorageKey);
   return resolveOpenAiApiKey({
     storedApiKey: apiKey,
-    storedSource: 'secure_store',
+    storedSource: "secure_store",
     embeddedApiKey: localOpenAiApiKey,
   }).apiKey;
 }

--- a/src/storage/appSettings.web.ts
+++ b/src/storage/appSettings.web.ts
@@ -1,46 +1,55 @@
-import { resolveOpenAiApiKey } from '../config/openAiKeyFallback';
-import type { OpenAiApiKeySource } from '../config/openAiKeyFallback';
-import { localOpenAiApiKey } from '../config/localOpenAiApiKey.generated';
+import { resolveOpenAiApiKey } from "../config/openAiKeyFallback";
+import type { OpenAiApiKeySource } from "../config/openAiKeyFallback";
+import { localOpenAiApiKey } from "../config/localOpenAiApiKey.generated";
 
 export type AppSettings = {
   hasOpenAiApiKey: boolean;
   openAiApiKeySource: OpenAiApiKeySource;
   defaultSyncRangeDays: number;
+  athleteName: string | null;
 };
 
 type StoredAppSettings = {
   defaultSyncRangeDays?: number;
+  athleteName?: string | null;
 };
 
-const openAiApiKeyStorageKey = 'biostream.openai_api_key';
-const appSettingsStorageKey = 'biostream.local_settings';
+const openAiApiKeyStorageKey = "biostream.openai_api_key";
+const appSettingsStorageKey = "biostream.local_settings";
 const fallbackSettings: StoredAppSettings = {
   defaultSyncRangeDays: 365,
 };
 const allowedSyncRanges = new Set([7, 30, 365]);
 
 function readLocalStorage(key: string): string | null {
-  return typeof localStorage === 'undefined' ? null : localStorage.getItem(key);
+  return typeof localStorage === "undefined" ? null : localStorage.getItem(key);
 }
 
 function writeLocalStorage(key: string, value: string): void {
-  if (typeof localStorage !== 'undefined') {
+  if (typeof localStorage !== "undefined") {
     localStorage.setItem(key, value);
   }
 }
 
 function removeLocalStorage(key: string): void {
-  if (typeof localStorage !== 'undefined') {
+  if (typeof localStorage !== "undefined") {
     localStorage.removeItem(key);
   }
 }
 
 function normalizeSettings(settings: StoredAppSettings): StoredAppSettings {
-  const defaultSyncRangeDays = allowedSyncRanges.has(Number(settings.defaultSyncRangeDays))
+  const defaultSyncRangeDays = allowedSyncRanges.has(
+    Number(settings.defaultSyncRangeDays),
+  )
     ? Number(settings.defaultSyncRangeDays)
     : fallbackSettings.defaultSyncRangeDays;
+  const athleteName =
+    typeof settings.athleteName === "string" && settings.athleteName.trim()
+      ? settings.athleteName.trim().slice(0, 80)
+      : null;
 
   return {
+    athleteName,
     defaultSyncRangeDays,
   };
 }
@@ -63,18 +72,21 @@ export async function loadAppSettings(): Promise<AppSettings> {
   const apiKey = readLocalStorage(openAiApiKeyStorageKey);
   const activeApiKey = resolveOpenAiApiKey({
     storedApiKey: apiKey,
-    storedSource: 'local_storage',
+    storedSource: "local_storage",
     embeddedApiKey: localOpenAiApiKey,
   });
 
   return {
+    athleteName: settings.athleteName ?? null,
     hasOpenAiApiKey: Boolean(activeApiKey.apiKey),
     openAiApiKeySource: activeApiKey.source,
     defaultSyncRangeDays: settings.defaultSyncRangeDays ?? 365,
   };
 }
 
-export async function saveAppSettings(settings: Partial<StoredAppSettings>): Promise<AppSettings> {
+export async function saveAppSettings(
+  settings: Partial<StoredAppSettings>,
+): Promise<AppSettings> {
   const current = await loadStoredSettings();
   const next = normalizeSettings({
     ...current,
@@ -88,7 +100,7 @@ export async function saveAppSettings(settings: Partial<StoredAppSettings>): Pro
 export async function saveOpenAiApiKey(apiKey: string): Promise<AppSettings> {
   const trimmed = apiKey.trim();
   if (!trimmed) {
-    throw new Error('Enter an API key before saving.');
+    throw new Error("Enter an API key before saving.");
   }
 
   writeLocalStorage(openAiApiKeyStorageKey, trimmed);
@@ -103,7 +115,7 @@ export async function clearOpenAiApiKey(): Promise<AppSettings> {
 export async function readOpenAiApiKey(): Promise<string | null> {
   return resolveOpenAiApiKey({
     storedApiKey: readLocalStorage(openAiApiKeyStorageKey),
-    storedSource: 'local_storage',
+    storedSource: "local_storage",
     embeddedApiKey: localOpenAiApiKey,
   }).apiKey;
 }


### PR DESCRIPTION
## Summary
- Remove the hardcoded Martin greeting from the coach screen.
- Add a locally saved preferred-name setting and pass it into onboarding and coach greetings.
- Fall back to a generic greeting when no preferred name is saved.

## Root cause
The coach screen always rendered a local `athleteName = "Martin"`, so every Android user saw the same greeting.

## Validation
- `npm test -- --runInBand`
- `npm run typecheck`
- `git diff --check HEAD^ HEAD`
