### PR TITLE
Track B daily recommendation output contract

### DIFF
--- a/src/coach/dailyRecommendation.test.ts
+++ b/src/coach/dailyRecommendation.test.ts
@@ -1,0 +1,63 @@
+import { buildReadinessStatus } from "./readinessStatus";
+import { buildDailyRecommendationFields } from "./dailyRecommendation";
+
+describe("daily recommendation contract", () => {
+  it("includes activity, easier alternative, avoid list, source awareness, and check-in question", () => {
+    const readinessStatus = buildReadinessStatus({
+      score: 84,
+      signalsUsed: ["sleep was 8h", "resting HR is down 4 bpm"],
+      sourceFreshness: [],
+    });
+
+    const recommendation = buildDailyRecommendationFields({
+      readinessStatus,
+      title: "Quality run",
+      detail: "10 min easy · 4 x 5 min strong · cool down",
+      reason: "Recovery supports a harder aerobic stimulus.",
+      readinessSignals: readinessStatus.signalsUsed,
+    });
+
+    expect(recommendation.recommendedActivity.title).toBe("Quality run");
+    expect(recommendation.recommendedActivity.intensityTarget).toBe(
+      "planned intensity",
+    );
+    expect(recommendation.easierAlternative.title).toBe("Short aerobic option");
+    expect(recommendation.whatToAvoidToday).toContain("large volume jumps");
+    expect(recommendation.sourcesUsed).toEqual([
+      "sleep was 8h",
+      "resting HR is down 4 bpm",
+    ]);
+    expect(recommendation.sourcesIgnored).toEqual([]);
+    expect(recommendation.confidence).toBeGreaterThanOrEqual(0.75);
+    expect(recommendation.checkInQuestion).toMatch(/soreness|illness/i);
+  });
+
+  it("reduces confidence and keeps guidance conservative when readiness is unknown", () => {
+    const readinessStatus = buildReadinessStatus({
+      score: 62,
+      signalsUsed: [],
+      sourceFreshness: [],
+    });
+
+    const recommendation = buildDailyRecommendationFields({
+      readinessStatus,
+      title: "Easy walk + mobility",
+      detail: "20-30 min easy movement",
+      reason: "Readiness is unknown, so today's call stays conservative.",
+      contextSignals: ["training load unavailable"],
+    });
+
+    expect(readinessStatus.status).toBe("unknown");
+    expect(recommendation.confidence).toBeLessThanOrEqual(0.35);
+    expect(recommendation.recommendedActivity.intensityTarget).toBe(
+      "easy until clearer",
+    );
+    expect(recommendation.easierAlternative.intensityTarget).toBe("very easy");
+    expect(recommendation.whatToAvoidToday).toContain("hard efforts");
+    expect(recommendation.sourcesUsed).toEqual([]);
+    expect(recommendation.sourcesIgnored).toContain(
+      "training load unavailable",
+    );
+    expect(recommendation.checkInQuestion).toMatch(/feel today/i);
+  });
+});

--- a/src/coach/dailyRecommendation.ts
+++ b/src/coach/dailyRecommendation.ts
@@ -1,0 +1,177 @@
+import type {
+  CoachRecommendation,
+  CoachRecommendationActivity,
+} from "../health/types";
+import type { ReadinessStatusContract } from "./readinessStatus";
+
+type DailyRecommendationFields = Pick<
+  CoachRecommendation,
+  | "shortExplanation"
+  | "recommendedActivity"
+  | "easierAlternative"
+  | "whatToAvoidToday"
+  | "confidence"
+  | "sourcesUsed"
+  | "sourcesIgnored"
+  | "checkInQuestion"
+>;
+
+export type CoachRecommendationBase = Omit<
+  CoachRecommendation,
+  keyof DailyRecommendationFields
+>;
+
+export type DailyRecommendationContractInput = {
+  readinessStatus: ReadinessStatusContract;
+  title: string;
+  detail: string;
+  reason: string;
+  readinessSignals?: string[];
+  contextSignals?: string[];
+};
+
+function unique(values: string[]): string[] {
+  return Array.from(
+    new Set(values.map((value) => value.trim()).filter(Boolean)),
+  );
+}
+
+function confidenceFor(status: ReadinessStatusContract): number {
+  if (status.status === "unknown") {
+    return Math.min(status.confidence, 0.35);
+  }
+
+  if (status.status === "red") {
+    return Math.min(status.confidence, 0.55);
+  }
+
+  if (status.status === "yellow") {
+    return Math.min(status.confidence, 0.74);
+  }
+
+  return status.confidence;
+}
+
+function intensityTarget(status: ReadinessStatusContract): string {
+  if (status.status === "green") return "planned intensity";
+  if (status.status === "red") return "easy only";
+  if (status.status === "unknown") return "easy until clearer";
+  return "controlled aerobic";
+}
+
+function easierAlternativeFor(
+  status: ReadinessStatusContract,
+): CoachRecommendationActivity {
+  if (status.status === "green") {
+    return {
+      title: "Short aerobic option",
+      intensityTarget: "easy conversational",
+      durationOrVolume: "25-35 min",
+      rationale:
+        "Use this if energy, soreness, or schedule changes after the data sync.",
+    };
+  }
+
+  if (status.status === "red" || status.status === "unknown") {
+    return {
+      title: "Walk and mobility",
+      intensityTarget: "very easy",
+      durationOrVolume: "10-20 min",
+      rationale:
+        "This keeps movement available without treating incomplete or poor readiness as a training green light.",
+    };
+  }
+
+  return {
+    title: "Shorten the aerobic work",
+    intensityTarget: "easy",
+    durationOrVolume: "20-30 min",
+    rationale:
+      "A shorter option keeps the habit while respecting mixed readiness signals.",
+  };
+}
+
+function avoidsFor(status: ReadinessStatusContract): string[] {
+  if (status.status === "green") {
+    return ["large volume jumps", "turning easy work into a race"];
+  }
+
+  if (status.status === "red") {
+    return ["hard intervals", "max efforts", "long sessions"];
+  }
+
+  if (status.status === "unknown") {
+    return ["hard efforts", "new maxes", "adding volume from incomplete data"];
+  }
+
+  return ["threshold work", "extra volume", "testing pace"];
+}
+
+function checkInFor(status: ReadinessStatusContract): string {
+  if (status.status === "green") {
+    return "Any soreness, illness, or schedule constraint before you start?";
+  }
+
+  if (status.status === "red") {
+    return "Is there pain, illness, or unusual fatigue I should account for today?";
+  }
+
+  if (status.status === "unknown") {
+    return "How do you feel today: rested, normal, tired, sore, or unwell?";
+  }
+
+  return "Do you feel normal enough to train, or should we shorten this?";
+}
+
+export function buildDailyRecommendationFields({
+  readinessStatus,
+  title,
+  detail,
+  reason,
+  readinessSignals = [],
+  contextSignals = [],
+}: DailyRecommendationContractInput): DailyRecommendationFields {
+  const sourcesUsed = unique(
+    readinessSignals.length ? readinessSignals : readinessStatus.signalsUsed,
+  );
+  const sourcesIgnored = unique([
+    ...readinessStatus.staleSignalsIgnored,
+    ...readinessStatus.missingSignals,
+    ...contextSignals,
+  ]);
+
+  return {
+    shortExplanation: reason,
+    recommendedActivity: {
+      title,
+      intensityTarget: intensityTarget(readinessStatus),
+      durationOrVolume: detail,
+      rationale: reason,
+    },
+    easierAlternative: easierAlternativeFor(readinessStatus),
+    whatToAvoidToday: avoidsFor(readinessStatus),
+    confidence: confidenceFor(readinessStatus),
+    sourcesUsed,
+    sourcesIgnored,
+    checkInQuestion: checkInFor(readinessStatus),
+  };
+}
+
+export function completeCoachRecommendation(
+  base: CoachRecommendationBase,
+  input: Omit<
+    DailyRecommendationContractInput,
+    "readinessStatus" | "title" | "detail" | "reason"
+  > = {},
+): CoachRecommendation {
+  return {
+    ...base,
+    ...buildDailyRecommendationFields({
+      readinessStatus: base.readinessStatus,
+      title: base.title,
+      detail: base.detail,
+      reason: base.reason,
+      ...input,
+    }),
+  };
+}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -8,6 +8,7 @@ import {
   Zap,
 } from "lucide-react-native";
 
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
 import { buildReadinessStatus } from "../coach/readinessStatus";
 import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
 import type { PipelineSnapshot } from "../health/types";
@@ -37,7 +38,7 @@ export const emptySnapshot: PipelineSnapshot = {
   recentWorkouts: [],
   recentSamples: [],
   trainingLoad: buildTrainingLoadSnapshot(),
-  recommendation: {
+  recommendation: completeCoachRecommendation({
     readiness: null,
     readinessStatus: buildReadinessStatus({
       score: null,
@@ -52,7 +53,7 @@ export const emptySnapshot: PipelineSnapshot = {
     opener: "Readiness is unknown, so I would keep today conservative.",
     strain: 0,
     strainTarget: "—",
-  },
+  }),
 };
 
 export const analyticsMetrics: AnalyticsMetricConfig[] = [

--- a/src/export/healthCheck.test.ts
+++ b/src/export/healthCheck.test.ts
@@ -1,5 +1,6 @@
 import type { PipelineSnapshot, SourceFreshness } from "../health/types";
 
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
 import { buildReadinessStatus } from "../coach/readinessStatus";
 import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
 import { generateHealthCheckMarkdown } from "./healthCheck";
@@ -89,7 +90,7 @@ function snapshot(overrides: Partial<PipelineSnapshot> = {}): PipelineSnapshot {
     recentWorkouts: [],
     recentSamples: [],
     trainingLoad: buildTrainingLoadSnapshot(),
-    recommendation: {
+    recommendation: completeCoachRecommendation({
       readiness: 62,
       readinessStatus: buildReadinessStatus({
         score: 62,
@@ -104,7 +105,7 @@ function snapshot(overrides: Partial<PipelineSnapshot> = {}): PipelineSnapshot {
       opener: "Use the current data conservatively.",
       strain: 5,
       strainTarget: "4-6",
-    },
+    }),
     ...overrides,
   };
 }
@@ -169,7 +170,7 @@ describe("generateHealthCheckMarkdown", () => {
         coverageDays: 0,
         sourceFreshness: [],
         today: null,
-        recommendation: {
+        recommendation: completeCoachRecommendation({
           readiness: null,
           readinessStatus: buildReadinessStatus({
             score: null,
@@ -185,7 +186,7 @@ describe("generateHealthCheckMarkdown", () => {
           opener: "Readiness is unknown, so I would keep today conservative.",
           strain: 0,
           strainTarget: "0",
-        },
+        }),
       }),
       { generatedAt },
     );

--- a/src/export/pipelineExport.test.ts
+++ b/src/export/pipelineExport.test.ts
@@ -1,5 +1,6 @@
 import type { PipelineSnapshot } from "../health/types";
 
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
 import { buildReadinessStatus } from "../coach/readinessStatus";
 import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
 import { buildPipelineExportArtifacts } from "./pipelineExport";
@@ -19,7 +20,7 @@ function snapshot(): PipelineSnapshot {
     recentWorkouts: [],
     recentSamples: [],
     trainingLoad: buildTrainingLoadSnapshot(),
-    recommendation: {
+    recommendation: completeCoachRecommendation({
       readiness: null,
       readinessStatus: buildReadinessStatus({
         score: null,
@@ -35,7 +36,7 @@ function snapshot(): PipelineSnapshot {
       opener: "Readiness is unknown, so I would keep today conservative.",
       strain: 0,
       strainTarget: "0",
-    },
+    }),
   };
 }
 

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -305,6 +305,13 @@ export type TrainingLoadSnapshot = {
 
 export type CoachTone = "positive" | "warm" | "cool" | "neutral";
 
+export type CoachRecommendationActivity = {
+  title: string;
+  intensityTarget: string;
+  durationOrVolume: string;
+  rationale: string;
+};
+
 export type CoachRecommendation = {
   readiness: number | null;
   readinessStatus: ReadinessStatusContract;
@@ -316,6 +323,14 @@ export type CoachRecommendation = {
   opener: string;
   strain: number;
   strainTarget: string;
+  shortExplanation: string;
+  recommendedActivity: CoachRecommendationActivity;
+  easierAlternative: CoachRecommendationActivity;
+  whatToAvoidToday: string[];
+  confidence: number;
+  sourcesUsed: string[];
+  sourcesIgnored: string[];
+  checkInQuestion: string;
 };
 
 export type MetricAvailability = {

--- a/src/screens/CoachScreen.tsx
+++ b/src/screens/CoachScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -16,7 +16,6 @@ import {
   RefreshCw,
 } from "lucide-react-native";
 
-import { generateTrainingPlan, resolveTrainingGoal } from "../coach/planEngine";
 import {
   dataAge,
   formatDateKey,
@@ -87,10 +86,6 @@ export function CoachScreen({
   const recommendation = snapshot.recommendation;
   const readinessStatus = recommendation.readinessStatus;
   const accent = toneColor(recommendation.color);
-  const plan = useMemo(
-    () => generateTrainingPlan(snapshot, resolveTrainingGoal(goalText)),
-    [goalText, snapshot],
-  );
   const sleep = current?.sleepSeconds
     ? formatDurationFromDates(current.sleepSeconds)
     : "—";
@@ -281,19 +276,41 @@ export function CoachScreen({
                 <Activity color={tokens.surface} size={18} strokeWidth={2} />
               </View>
               <View style={styles.planCopy}>
-                <Text style={styles.planTitle}>{plan.today.title}</Text>
+                <Text style={styles.planTitle}>
+                  {recommendation.recommendedActivity.title}
+                </Text>
                 <View style={styles.coachPlanStats}>
                   <Text style={styles.coachPlanStat}>
-                    {plan.today.durationMinutes}:00
+                    {recommendation.recommendedActivity.durationOrVolume}
                   </Text>
-                  <Text style={styles.coachPlanStat}>~7.2 km</Text>
                   <Text style={styles.coachPlanStat}>
-                    {plan.today.intensity}
+                    {recommendation.recommendedActivity.intensityTarget}
+                  </Text>
+                  <Text style={styles.coachPlanStat}>
+                    {Math.round(recommendation.confidence * 100)}% confidence
                   </Text>
                 </View>
                 <Text style={styles.planDetail}>
-                  Your {wearableLabel} will capture distance, pace, heart rate,
-                  route, splits, and duration.
+                  {recommendation.shortExplanation}
+                </Text>
+                <Text style={styles.planDetail}>
+                  Easier: {recommendation.easierAlternative.title} ·{" "}
+                  {recommendation.easierAlternative.durationOrVolume}.
+                </Text>
+                <Text style={styles.planDetail}>
+                  Avoid: {recommendation.whatToAvoidToday.join(", ")}.
+                </Text>
+                <Text style={styles.planDetail}>
+                  Sources:{" "}
+                  {recommendation.sourcesUsed.length
+                    ? recommendation.sourcesUsed.join(", ")
+                    : "no usable readiness sources"}
+                  {recommendation.sourcesIgnored.length
+                    ? ` · Ignored: ${recommendation.sourcesIgnored.join(", ")}`
+                    : ""}
+                </Text>
+                <Text style={styles.planDetail}>
+                  Check-in: {recommendation.checkInQuestion}
                 </Text>
               </View>
               <ArrowRight color={tokens.muted} size={17} strokeWidth={2} />

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -2,6 +2,7 @@ import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import * as SQLite from "expo-sqlite";
 
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
 import { extractRiskFlagsFromCoachRequest } from "../coach/riskFlags";
 import { buildReadinessStatus } from "../coach/readinessStatus";
 import {
@@ -2579,7 +2580,7 @@ function deriveRecommendation(
       sourceFreshness,
     });
 
-    return {
+    return completeCoachRecommendation({
       readiness: null,
       readinessStatus,
       readinessLabel: readinessStatus.ui.label,
@@ -2590,7 +2591,7 @@ function deriveRecommendation(
       opener: readinessStatus.ui.opener,
       strain: 0,
       strainTarget: "—",
-    };
+    });
   }
 
   const baselineRows = history
@@ -2716,62 +2717,74 @@ function deriveRecommendation(
       : [readinessStatus.ui.reason];
 
   if (readinessStatus.status === "unknown") {
-    return {
-      readiness: readinessStatus.score,
-      readinessStatus,
-      readinessLabel: readinessStatus.ui.label,
-      color: readinessStatus.ui.color,
-      title: "Easy walk + mobility",
-      detail: "20-30 min easy movement · optional mobility",
-      reason: `${coachSignals.join(", ")}. Readiness is unknown, so today's call stays conservative.`,
-      opener: `Readiness is unknown. ${coachSignals.join(", ")}. I would keep this easy until the recovery picture is clearer.`,
-      strain: 4,
-      strainTarget: "3-5",
-    };
+    return completeCoachRecommendation(
+      {
+        readiness: readinessStatus.score,
+        readinessStatus,
+        readinessLabel: readinessStatus.ui.label,
+        color: readinessStatus.ui.color,
+        title: "Easy walk + mobility",
+        detail: "20-30 min easy movement · optional mobility",
+        reason: `${coachSignals.join(", ")}. Readiness is unknown, so today's call stays conservative.`,
+        opener: `Readiness is unknown. ${coachSignals.join(", ")}. I would keep this easy until the recovery picture is clearer.`,
+        strain: 4,
+        strainTarget: "3-5",
+      },
+      { readinessSignals, contextSignals },
+    );
   }
 
   if (readinessStatus.status === "red") {
-    return {
-      readiness: readinessStatus.score,
-      readinessStatus,
-      readinessLabel: readinessStatus.ui.label,
-      color: readinessStatus.ui.color,
-      title: "Easy walk + mobility",
-      detail: "30 min Z1 walk · 10 min hips and calves",
-      reason: `${coachSignals.join(", ")}. Pushing hard today would reduce the odds of stacking the next session well.`,
-      opener: `Honest check-in: ${coachSignals.join(", ")}. I would keep this soft and earn tomorrow.`,
-      strain: 5.5,
-      strainTarget: "4-7",
-    };
+    return completeCoachRecommendation(
+      {
+        readiness: readinessStatus.score,
+        readinessStatus,
+        readinessLabel: readinessStatus.ui.label,
+        color: readinessStatus.ui.color,
+        title: "Easy walk + mobility",
+        detail: "30 min Z1 walk · 10 min hips and calves",
+        reason: `${coachSignals.join(", ")}. Pushing hard today would reduce the odds of stacking the next session well.`,
+        opener: `Honest check-in: ${coachSignals.join(", ")}. I would keep this soft and earn tomorrow.`,
+        strain: 5.5,
+        strainTarget: "4-7",
+      },
+      { readinessSignals, contextSignals },
+    );
   }
 
   if (readinessStatus.status === "green" && (current.workoutCount ?? 0) === 0) {
-    return {
+    return completeCoachRecommendation(
+      {
+        readiness: readinessStatus.score,
+        readinessStatus,
+        readinessLabel: readinessStatus.ui.label,
+        color: readinessStatus.ui.color,
+        title: "Quality run",
+        detail: "10 min easy · 4 x 5 min strong · cool down",
+        reason: `${coachSignals.join(", ")}. Current recovery supports a harder aerobic stimulus.`,
+        opener: `You're primed. ${coachSignals.join(", ")}. If you were waiting for a green light, this is it.`,
+        strain: 13.5,
+        strainTarget: "12-15",
+      },
+      { readinessSignals, contextSignals },
+    );
+  }
+
+  return completeCoachRecommendation(
+    {
       readiness: readinessStatus.score,
       readinessStatus,
       readinessLabel: readinessStatus.ui.label,
       color: readinessStatus.ui.color,
-      title: "Quality run",
-      detail: "10 min easy · 4 x 5 min strong · cool down",
-      reason: `${coachSignals.join(", ")}. Current recovery supports a harder aerobic stimulus.`,
-      opener: `You're primed. ${coachSignals.join(", ")}. If you were waiting for a green light, this is it.`,
-      strain: 13.5,
-      strainTarget: "12-15",
-    };
-  }
-
-  return {
-    readiness: readinessStatus.score,
-    readinessStatus,
-    readinessLabel: readinessStatus.ui.label,
-    color: readinessStatus.ui.color,
-    title: "Aerobic base",
-    detail: "45 min easy run or ride · stay conversational",
-    reason: `${coachSignals.join(", ")}. This is a good day to add durable aerobic volume without forcing intensity.`,
-    opener: `Solid baseline today. ${coachSignals.join(", ")}. Stack the work and keep it controlled.`,
-    strain: 9.5,
-    strainTarget: "8-11",
-  };
+      title: "Aerobic base",
+      detail: "45 min easy run or ride · stay conversational",
+      reason: `${coachSignals.join(", ")}. This is a good day to add durable aerobic volume without forcing intensity.`,
+      opener: `Solid baseline today. ${coachSignals.join(", ")}. Stack the work and keep it controlled.`,
+      strain: 9.5,
+      strainTarget: "8-11",
+    },
+    { readinessSignals, contextSignals },
+  );
 }
 
 export async function getPipelineSnapshot(): Promise<PipelineSnapshot> {

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -10,6 +10,7 @@ import type {
   SyncRange,
 } from "../health/types";
 import { emptySnapshot } from "../core/constants";
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
 import { buildReadinessStatus } from "../coach/readinessStatus";
 import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
 import { buildPipelineExportArtifacts } from "../export/pipelineExport";
@@ -423,7 +424,7 @@ const demoSnapshot: PipelineSnapshot = {
   ],
   recentSamples: [],
   trainingLoad: buildTrainingLoadSnapshot(),
-  recommendation: {
+  recommendation: completeCoachRecommendation({
     readiness: 78,
     readinessStatus: demoReadinessStatus,
     readinessLabel: demoReadinessStatus.ui.label,
@@ -436,7 +437,7 @@ const demoSnapshot: PipelineSnapshot = {
       "Morning. Your wearable data already shows a strong recovery profile today.",
     strain: 9.5,
     strainTarget: "8-11",
-  },
+  }),
 };
 
 let lastSync: SyncRunRow | null = {


### PR DESCRIPTION
## Summary
- add deterministic daily recommendation contract fields to coach recommendations
- expose recommended activity, easier alternative, avoid list, confidence, source usage, and check-in question
- render the contract in the coach workout card

## Verification
- npm test -- --runInBand src/coach/dailyRecommendation.test.ts src/export/healthCheck.test.ts src/export/pipelineExport.test.ts
- npm run typecheck
- git diff --check

Fixes #17