### PR TITLE
[codex] Disable automatic test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,7 @@
 name: Tests
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Disable automatic `Tests` workflow runs on PRs and pushes to `main`.
- Keep the workflow available via manual `workflow_dispatch` from GitHub Actions.

## Validation
- `git diff --check HEAD^ HEAD`
