### PR TITLE
[codex] Cover Health Connect range chunking

### DIFF
--- a/src/health/ranges.test.ts
+++ b/src/health/ranges.test.ts
@@ -1,0 +1,50 @@
+import { splitSyncRangeByDays } from "./ranges";
+
+describe("splitSyncRangeByDays", () => {
+  it("splits a long range into contiguous chunks", () => {
+    const chunks = splitSyncRangeByDays(
+      {
+        startDate: new Date("2026-01-01T00:00:00.000Z"),
+        endDate: new Date("2026-03-07T15:30:00.000Z"),
+      },
+      30,
+    );
+
+    expect(chunks.map((chunk) => chunk.startDate.toISOString())).toEqual([
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-31T00:00:00.000Z",
+      "2026-03-02T00:00:00.000Z",
+    ]);
+    expect(chunks.map((chunk) => chunk.endDate.toISOString())).toEqual([
+      "2026-01-31T00:00:00.000Z",
+      "2026-03-02T00:00:00.000Z",
+      "2026-03-07T15:30:00.000Z",
+    ]);
+  });
+
+  it("keeps short ranges as a single chunk", () => {
+    const range = {
+      startDate: new Date("2026-04-01T00:00:00.000Z"),
+      endDate: new Date("2026-04-08T12:00:00.000Z"),
+    };
+
+    expect(splitSyncRangeByDays(range, 30)).toEqual([
+      {
+        startDate: new Date(range.startDate),
+        endDate: new Date(range.endDate),
+      },
+    ]);
+  });
+
+  it("rejects non-positive chunk sizes", () => {
+    expect(() =>
+      splitSyncRangeByDays(
+        {
+          startDate: new Date("2026-04-01T00:00:00.000Z"),
+          endDate: new Date("2026-04-08T12:00:00.000Z"),
+        },
+        0,
+      ),
+    ).toThrow("maxDays must be greater than zero");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused Jest coverage for the Health Connect sync range chunking helper introduced to reduce native aggregate stalls.

## Root cause

The device warning came from Health Connect aggregate reads timing out over large sync ranges. `origin/main` now mitigates that by defaulting new syncs to 30 days and chunking the heavier aggregate types (`TotalCaloriesBurned`, `Distance`, and `HeartRate`) into 30-day windows. This PR protects the range splitter that behavior depends on.

## Validation

- `npm test -- --runTestsByPath src/health/ranges.test.ts --runInBand`
- `npm run typecheck`
- `git diff --check`