### PR TITLE
Add llm bundle export

### DIFF
--- a/src/export/llmBundle.test.ts
+++ b/src/export/llmBundle.test.ts
@@ -40,6 +40,7 @@ function snapshot(): PipelineSnapshot {
         canonicalTypes: ["sleep_session"],
         sampleCount: 4,
         dayCount: 4,
+        earliestLocalDate: "2026-04-20",
         latestLocalDate: "2026-04-28",
         lastUpdatedAt: "2026-04-29T03:30:00.000Z",
         ageDays: 1,
@@ -123,6 +124,8 @@ function snapshot(): PipelineSnapshot {
         }),
       },
     ],
+    todayCheckIn: null,
+    checkInHistory: [],
     trainingLoad: buildTrainingLoadSnapshot(),
     recommendation: completeCoachRecommendation({
       readiness: 82,
@@ -188,7 +191,7 @@ describe("buildLlmBundle", () => {
     expect(bundle.dailyCheckIn.checkInHistory).toEqual([]);
     expect(bundle.sourceFreshness[0]).toMatchObject({
       name: "Sleep",
-      dateRange: { start: "2026-04-28", end: "2026-04-28" },
+      dateRange: { start: "2026-04-20", end: "2026-04-28" },
       lastUpdatedAt: "2026-04-29T03:30:00.000Z",
       confidenceOrCompleteness: "fresh",
       staleness: { state: "fresh", ageDays: 1 },
@@ -207,6 +210,90 @@ describe("buildLlmBundle", () => {
     );
     expect(JSON.stringify(bundle)).not.toContain("rawJson");
     expect(JSON.stringify(bundle)).not.toContain("metadataJson");
+  });
+
+  it("exports only allowlisted daily check-in fields", () => {
+    const bundle = buildLlmBundle(snapshot(), {
+      exportedAt: "2026-04-29T05:00:00.000Z",
+      currentCheckIn: {
+        localDate: "2026-04-29",
+        sleepQuality: 4,
+        soreness: 2,
+        energy: 3,
+        pain: "moderate",
+        availableTimeMinutes: 45,
+        preferredActivity: "mobility",
+        completedYesterday: false,
+        source: "user_reported",
+        createdAt: "2026-04-29T04:00:00.000Z",
+        updatedAt: "2026-04-29T04:30:00.000Z",
+        date: "2026-04-29",
+        checkedInAt: "2026-04-29T04:30:00.000Z",
+        mood: "Sharp pain words should not leak",
+        stress: "fever words should not leak",
+        fatigue: "faint words should not leak",
+        illness: "illness words should not leak",
+        constraints: ["chest pain words should not leak"],
+        readiness: "red flag words should not leak",
+        rawRecords: [{ private: true }],
+        metadataJson: '{"leak":true}',
+        nestedRawPayload: { symptomSurvey: "sharp pain should not leak" },
+      },
+      checkInHistory: [
+        {
+          localDate: "2026-04-28",
+          sleepQuality: 3,
+          soreness: 3,
+          energy: 5,
+          pain: "none",
+          availableTimeMinutes: 30,
+          preferredActivity: "easy_cardio",
+          completedYesterday: true,
+          source: "user_reported",
+          internalId: "checkin-raw-1",
+        },
+      ],
+    });
+
+    expect(bundle.dailyCheckIn.currentCheckIn).toEqual({
+      localDate: "2026-04-29",
+      sleepQuality: 4,
+      soreness: 2,
+      energy: 3,
+      pain: "moderate",
+      availableTimeMinutes: 45,
+      preferredActivity: "mobility",
+      completedYesterday: false,
+      source: "user_reported",
+      createdAt: "2026-04-29T04:00:00.000Z",
+      updatedAt: "2026-04-29T04:30:00.000Z",
+    });
+    expect(bundle.dailyCheckIn.checkInHistory).toEqual([
+      {
+        localDate: "2026-04-28",
+        sleepQuality: 3,
+        soreness: 3,
+        energy: 5,
+        pain: "none",
+        availableTimeMinutes: 30,
+        preferredActivity: "easy_cardio",
+        completedYesterday: true,
+        source: "user_reported",
+      },
+    ]);
+    expect(bundle.riskFlags.highest_severity).toBe("none");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("rawRecords");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("metadataJson");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("internalId");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("checkedInAt");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("mood");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("constraints");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain("readiness");
+    expect(JSON.stringify(bundle.dailyCheckIn)).not.toContain(
+      "nestedRawPayload",
+    );
+    expect(JSON.stringify(bundle.riskFlags)).not.toContain("sharp pain");
+    expect(JSON.stringify(bundle.riskFlags)).not.toContain("chest pain");
   });
 
   it("keeps the llm bundle smaller than a full raw export payload", () => {

--- a/src/export/llmBundle.test.ts
+++ b/src/export/llmBundle.test.ts
@@ -1,0 +1,232 @@
+import { completeCoachRecommendation } from "../coach/dailyRecommendation";
+import { buildReadinessStatus } from "../coach/readinessStatus";
+import { buildTrainingLoadSnapshot } from "../coach/trainingLoad";
+import { normalizeGoalProfile } from "../goals/goalProfile";
+import type { PipelineSnapshot } from "../health/types";
+import { buildLlmBundle } from "./llmBundle";
+
+function snapshot(): PipelineSnapshot {
+  const readinessStatus = buildReadinessStatus({
+    score: 82,
+    signalsUsed: ["sleep", "recent activity"],
+    sourceFreshness: [],
+  });
+
+  return {
+    totalSamples: 480,
+    workoutCount: 3,
+    sleepCount: 4,
+    nutritionDays: 2,
+    coverageDays: 7,
+    metricAvailability: [
+      {
+        canonicalType: "steps",
+        sampleCount: 7,
+        dayCount: 7,
+        latestDate: "2026-04-28",
+      },
+      {
+        canonicalType: "sleep_session",
+        sampleCount: 4,
+        dayCount: 4,
+        latestDate: "2026-04-28",
+      },
+    ],
+    sourceFreshness: [
+      {
+        domain: "sleep",
+        label: "Sleep",
+        state: "fresh",
+        canonicalTypes: ["sleep_session"],
+        sampleCount: 4,
+        dayCount: 4,
+        latestLocalDate: "2026-04-28",
+        lastUpdatedAt: "2026-04-29T03:30:00.000Z",
+        ageDays: 1,
+        limitations: [],
+      },
+      {
+        domain: "nutrition",
+        label: "Nutrition",
+        state: "stale",
+        canonicalTypes: ["nutrition"],
+        sampleCount: 2,
+        dayCount: 2,
+        latestLocalDate: "2026-04-24",
+        lastUpdatedAt: "2026-04-24T08:15:00.000Z",
+        ageDays: 5,
+        limitations: ["Nutrition has not synced recently."],
+      },
+    ],
+    latestDiagnostics: [],
+    today: {
+      date: "2026-04-29",
+      dataCompleteness: "partial",
+      wellnessDataStatus: "usable",
+      sourceCount: 3,
+      hasPlatformWellness: true,
+      hasActivity: true,
+      hasNutrition: false,
+      hasSleep: true,
+      hasSteps: true,
+      hasEnergy: true,
+      steps: 8200,
+      sleepSeconds: 27000,
+      restingHr: 52,
+      workoutCount: 1,
+      generatedAt: "2026-04-29T04:00:00.000Z",
+    },
+    history: [
+      {
+        date: "2026-04-28",
+        dataCompleteness: "full",
+        wellnessDataStatus: "complete",
+        sourceCount: 4,
+        hasPlatformWellness: true,
+        hasActivity: true,
+        hasNutrition: true,
+        hasSleep: true,
+        hasSteps: true,
+        hasEnergy: true,
+        steps: 9400,
+        sleepSeconds: 28800,
+        restingHr: 51,
+        workoutCount: 1,
+        generatedAt: "2026-04-28T04:00:00.000Z",
+      },
+    ],
+    recentWorkouts: [
+      {
+        workoutId: "workout-1",
+        platform: "health_connect",
+        startAt: "2026-04-28T20:00:00.000Z",
+        endAt: "2026-04-28T20:45:00.000Z",
+        localDate: "2026-04-29",
+        sportBucket: "run",
+        elapsedSeconds: 2700,
+        rawJson: JSON.stringify({ large: "raw workout payload".repeat(200) }),
+      },
+    ],
+    recentSamples: [
+      {
+        sampleId: "sample-1",
+        platform: "health_connect",
+        recordType: "Steps",
+        canonicalType: "steps",
+        startAt: "2026-04-28T00:00:00.000Z",
+        endAt: "2026-04-28T23:59:59.000Z",
+        localDate: "2026-04-28",
+        value: 9400,
+        unit: "count",
+        metadataJson: JSON.stringify({
+          large: "raw sample metadata".repeat(200),
+        }),
+      },
+    ],
+    trainingLoad: buildTrainingLoadSnapshot(),
+    recommendation: completeCoachRecommendation({
+      readiness: 82,
+      readinessStatus,
+      readinessLabel: "Ready",
+      color: "positive",
+      title: "Quality aerobic day",
+      detail: "45 min easy run",
+      reason: "Sleep and activity are current enough for a normal plan.",
+      opener: "You are ready for controlled work.",
+      strain: 9,
+      strainTarget: "8-11",
+    }),
+  };
+}
+
+describe("buildLlmBundle", () => {
+  it("builds the source-aware llm_bundle schema without raw records", () => {
+    const bundle = buildLlmBundle(snapshot(), {
+      exportedAt: "2026-04-29T05:00:00.000Z",
+      goalProfile: normalizeGoalProfile(
+        {
+          primaryGoal: "event_preparation",
+          secondaryGoals: ["endurance"],
+          motivation: "Run a half marathon well.",
+          timeframe: "12 weeks",
+          experienceLevel: "recreational",
+          preferredActivities: ["run", "strength"],
+          constraints: ["weekday mornings only"],
+          riskFlags: ["significant pain"],
+          coachingStyle: "direct",
+          startingStrategy: "event_phases",
+          confidence: 0.8,
+        },
+        "2026-04-20T00:00:00.000Z",
+      ),
+    });
+
+    expect(bundle.schema).toBe("biostream_llm_bundle.v1");
+    expect(bundle.exportedAt).toBe("2026-04-29T05:00:00.000Z");
+    expect(bundle.currentState).toMatchObject({
+      date: "2026-04-29",
+      readiness: {
+        score: 82,
+        status: "green",
+      },
+      today: {
+        dataCompleteness: "partial",
+        steps: 8200,
+        sleepSeconds: 27000,
+      },
+      trainingLoad: {
+        training_load_status: "unavailable",
+      },
+    });
+    expect(bundle.goalProfile?.primaryGoal).toBe("event_preparation");
+    expect(bundle.eventProfile).toMatchObject({
+      eventIntent: true,
+      timeframe: "12 weeks",
+      confidence: 0.8,
+    });
+    expect(bundle.dailyCheckIn.currentCheckIn).toBeNull();
+    expect(bundle.dailyCheckIn.checkInHistory).toEqual([]);
+    expect(bundle.sourceFreshness[0]).toMatchObject({
+      name: "Sleep",
+      dateRange: { start: "2026-04-28", end: "2026-04-28" },
+      lastUpdatedAt: "2026-04-29T03:30:00.000Z",
+      confidenceOrCompleteness: "fresh",
+      staleness: { state: "fresh", ageDays: 1 },
+      recommendationUsability: "usable",
+      limitations: [],
+    });
+    expect(bundle.riskFlags.items[0]).toMatchObject({
+      source: "goal_profile",
+      severity: "high",
+    });
+    expect(bundle.dataLimitations).toEqual(
+      expect.arrayContaining([
+        "Raw health samples, raw workouts, route streams, laps, and metadata JSON are intentionally excluded from this LLM bundle.",
+        "Nutrition has not synced recently.",
+      ]),
+    );
+    expect(JSON.stringify(bundle)).not.toContain("rawJson");
+    expect(JSON.stringify(bundle)).not.toContain("metadataJson");
+  });
+
+  it("keeps the llm bundle smaller than a full raw export payload", () => {
+    const fullRawExport = {
+      schema: "biostream_training_pipeline.v5",
+      exportedAt: "2026-04-29T05:00:00.000Z",
+      samples: snapshot().recentSamples,
+      workouts: snapshot().recentWorkouts,
+      dailyMetrics: [snapshot().today, ...snapshot().history],
+      sourceFreshness: snapshot().sourceFreshness,
+      trainingLoad: snapshot().trainingLoad,
+      recommendation: snapshot().recommendation,
+    };
+
+    const bundle = buildLlmBundle(snapshot(), {
+      exportedAt: "2026-04-29T05:00:00.000Z",
+    });
+
+    expect(JSON.stringify(bundle).length).toBeLessThan(
+      JSON.stringify(fullRawExport).length,
+    );
+  });
+});

--- a/src/export/llmBundle.ts
+++ b/src/export/llmBundle.ts
@@ -4,10 +4,30 @@ import { toTrainingLoadExport } from "../coach/trainingLoad";
 import type { GoalProfile } from "../goals/goalProfile";
 import type {
   CoachRecommendation,
+  DailyCheckIn,
   DailyMetrics,
   PipelineSnapshot,
   SourceFreshness,
 } from "../health/types";
+
+type LlmBundleCheckInValue = string | number | boolean | string[] | null;
+
+export type LlmBundleCheckIn = Partial<
+  Record<
+    | "localDate"
+    | "energy"
+    | "soreness"
+    | "sleepQuality"
+    | "pain"
+    | "availableTimeMinutes"
+    | "preferredActivity"
+    | "completedYesterday"
+    | "source"
+    | "createdAt"
+    | "updatedAt",
+    LlmBundleCheckInValue
+  >
+>;
 
 export type LlmBundleSource = {
   name: string;
@@ -31,8 +51,14 @@ export type LlmBundleOptions = {
   exportedAt?: string | Date;
   goalProfile?: GoalProfile | null;
   riskFlags?: RiskFlags | null;
-  currentCheckIn?: unknown | null;
-  checkInHistory?: unknown[];
+  currentCheckIn?:
+    | DailyCheckIn
+    | LlmBundleCheckIn
+    | Record<string, unknown>
+    | null;
+  checkInHistory?: Array<
+    DailyCheckIn | LlmBundleCheckIn | Record<string, unknown>
+  >;
 };
 
 export type LlmBundle = {
@@ -76,8 +102,8 @@ export type LlmBundle = {
     confidence: number;
   };
   dailyCheckIn: {
-    currentCheckIn: unknown | null;
-    checkInHistory: unknown[];
+    currentCheckIn: LlmBundleCheckIn | null;
+    checkInHistory: LlmBundleCheckIn[];
   };
   sourceFreshness: LlmBundleSource[];
   riskFlags: RiskFlags;
@@ -100,15 +126,44 @@ function recommendationUsability(
   return "unusable";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function localDateFromUtc(value: number): string {
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+function derivedDateRange(
+  source: SourceFreshness,
+): LlmBundleSource["dateRange"] {
+  const end = source.latestLocalDate ?? null;
+  if (!end) {
+    return { start: null, end: null };
+  }
+
+  if (source.earliestLocalDate) {
+    return { start: source.earliestLocalDate, end };
+  }
+
+  const endTime = Date.parse(`${end}T00:00:00.000Z`);
+  if (!Number.isFinite(endTime) || source.dayCount <= 1) {
+    return { start: end, end };
+  }
+  const dayMs = 24 * 60 * 60 * 1000;
+  const startTime = endTime - (source.dayCount - 1) * dayMs;
+  return {
+    start: localDateFromUtc(startTime),
+    end,
+  };
+}
+
 function toBundleSource(source: SourceFreshness): LlmBundleSource {
   return {
     name: source.label,
     domain: source.domain,
     canonicalTypes: source.canonicalTypes,
-    dateRange: {
-      start: source.latestLocalDate ?? null,
-      end: source.latestLocalDate ?? null,
-    },
+    dateRange: derivedDateRange(source),
     lastUpdatedAt: source.lastUpdatedAt ?? null,
     confidenceOrCompleteness: source.state,
     staleness: {
@@ -118,6 +173,51 @@ function toBundleSource(source: SourceFreshness): LlmBundleSource {
     recommendationUsability: recommendationUsability(source),
     limitations: source.limitations,
   };
+}
+
+const checkInFields = [
+  "localDate",
+  "energy",
+  "soreness",
+  "sleepQuality",
+  "pain",
+  "availableTimeMinutes",
+  "preferredActivity",
+  "completedYesterday",
+  "source",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+function compactCheckIn(value: unknown): LlmBundleCheckIn | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const output: LlmBundleCheckIn = {};
+  for (const field of checkInFields) {
+    const candidate = value[field];
+    if (
+      candidate == null ||
+      typeof candidate === "string" ||
+      typeof candidate === "number" ||
+      typeof candidate === "boolean"
+    ) {
+      if (candidate !== undefined) {
+        output[field] = candidate;
+      }
+      continue;
+    }
+
+    if (
+      Array.isArray(candidate) &&
+      candidate.every((item): item is string => typeof item === "string")
+    ) {
+      output[field] = candidate;
+    }
+  }
+
+  return Object.keys(output).length ? output : null;
 }
 
 function compactDailyMetrics(row: DailyMetrics): Partial<DailyMetrics> {
@@ -163,12 +263,18 @@ export function buildLlmBundle(
   const exportedAt = isoString(options.exportedAt);
   const goalProfile = options.goalProfile ?? null;
   const readiness = snapshot.recommendation.readinessStatus;
+  const currentCheckIn = compactCheckIn(
+    options.currentCheckIn ?? snapshot.todayCheckIn,
+  );
+  const checkInHistory = (options.checkInHistory ?? snapshot.checkInHistory)
+    .map(compactCheckIn)
+    .filter((checkIn): checkIn is LlmBundleCheckIn => checkIn !== null);
   const riskFlags =
     options.riskFlags ??
     extractRiskFlagsFromCoachRequest({
       generated_at: exportedAt,
       goal_profile: goalProfile ?? undefined,
-      daily_check_in: options.currentCheckIn ?? undefined,
+      daily_check_in: currentCheckIn ?? undefined,
     });
 
   return {
@@ -211,8 +317,8 @@ export function buildLlmBundle(
       confidence: goalProfile?.confidence ?? 0,
     },
     dailyCheckIn: {
-      currentCheckIn: options.currentCheckIn ?? null,
-      checkInHistory: options.checkInHistory ?? [],
+      currentCheckIn,
+      checkInHistory,
     },
     sourceFreshness: snapshot.sourceFreshness.map(toBundleSource),
     riskFlags,

--- a/src/export/llmBundle.ts
+++ b/src/export/llmBundle.ts
@@ -1,0 +1,221 @@
+import { extractRiskFlagsFromCoachRequest } from "../coach/riskFlags";
+import type { RiskFlags } from "../coach/schemas";
+import { toTrainingLoadExport } from "../coach/trainingLoad";
+import type { GoalProfile } from "../goals/goalProfile";
+import type {
+  CoachRecommendation,
+  DailyMetrics,
+  PipelineSnapshot,
+  SourceFreshness,
+} from "../health/types";
+
+export type LlmBundleSource = {
+  name: string;
+  domain: SourceFreshness["domain"];
+  canonicalTypes: SourceFreshness["canonicalTypes"];
+  dateRange: {
+    start: string | null;
+    end: string | null;
+  };
+  lastUpdatedAt: string | null;
+  confidenceOrCompleteness: string;
+  staleness: {
+    state: SourceFreshness["state"];
+    ageDays: number | null;
+  };
+  recommendationUsability: "usable" | "limited" | "unusable";
+  limitations: string[];
+};
+
+export type LlmBundleOptions = {
+  exportedAt?: string | Date;
+  goalProfile?: GoalProfile | null;
+  riskFlags?: RiskFlags | null;
+  currentCheckIn?: unknown | null;
+  checkInHistory?: unknown[];
+};
+
+export type LlmBundle = {
+  schema: "biostream_llm_bundle.v1";
+  exportedAt: string;
+  currentState: {
+    date: string | null;
+    readiness: {
+      score: number | null;
+      status: CoachRecommendation["readinessStatus"]["status"];
+      confidence: number;
+      summary: string;
+      signalsUsed: string[];
+      missingSignals: string[];
+      staleSignalsIgnored: string[];
+    };
+    today: Partial<DailyMetrics> | null;
+    recommendation: Pick<
+      CoachRecommendation,
+      | "title"
+      | "detail"
+      | "reason"
+      | "shortExplanation"
+      | "recommendedActivity"
+      | "easierAlternative"
+      | "whatToAvoidToday"
+      | "confidence"
+      | "sourcesUsed"
+      | "sourcesIgnored"
+      | "checkInQuestion"
+    >;
+    trainingLoad: ReturnType<typeof toTrainingLoadExport>;
+  };
+  recentHistory: Array<Partial<DailyMetrics>>;
+  goalProfile: GoalProfile | null;
+  eventProfile: {
+    eventIntent: boolean;
+    timeframe: string | null;
+    preferredActivities: string[];
+    constraints: string[];
+    confidence: number;
+  };
+  dailyCheckIn: {
+    currentCheckIn: unknown | null;
+    checkInHistory: unknown[];
+  };
+  sourceFreshness: LlmBundleSource[];
+  riskFlags: RiskFlags;
+  dataLimitations: string[];
+};
+
+function isoString(value: string | Date | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value ?? new Date().toISOString();
+}
+
+function recommendationUsability(
+  source: SourceFreshness,
+): LlmBundleSource["recommendationUsability"] {
+  if (source.state === "fresh") return "usable";
+  if (source.state === "partial") return "limited";
+  return "unusable";
+}
+
+function toBundleSource(source: SourceFreshness): LlmBundleSource {
+  return {
+    name: source.label,
+    domain: source.domain,
+    canonicalTypes: source.canonicalTypes,
+    dateRange: {
+      start: source.latestLocalDate ?? null,
+      end: source.latestLocalDate ?? null,
+    },
+    lastUpdatedAt: source.lastUpdatedAt ?? null,
+    confidenceOrCompleteness: source.state,
+    staleness: {
+      state: source.state,
+      ageDays: source.ageDays ?? null,
+    },
+    recommendationUsability: recommendationUsability(source),
+    limitations: source.limitations,
+  };
+}
+
+function compactDailyMetrics(row: DailyMetrics): Partial<DailyMetrics> {
+  return {
+    date: row.date,
+    dataCompleteness: row.dataCompleteness,
+    wellnessDataStatus: row.wellnessDataStatus,
+    sourceCount: row.sourceCount,
+    hasActivity: row.hasActivity,
+    hasNutrition: row.hasNutrition,
+    hasSleep: row.hasSleep,
+    hasSteps: row.hasSteps,
+    hasEnergy: row.hasEnergy,
+    steps: row.steps,
+    activeKcal: row.activeKcal,
+    totalKcal: row.totalKcal,
+    distanceKm: row.distanceKm,
+    sleepSeconds: row.sleepSeconds,
+    sleepEfficiency: row.sleepEfficiency,
+    restingHr: row.restingHr,
+    hrvLastNightAvg: row.hrvLastNightAvg,
+    workoutCount: row.workoutCount,
+    activityElapsedSeconds: row.activityElapsedSeconds,
+    kcalIn: row.kcalIn,
+    proteinG: row.proteinG,
+    waterMl: row.waterMl,
+    generatedAt: row.generatedAt,
+  };
+}
+
+function dataLimitations(snapshot: PipelineSnapshot): string[] {
+  return [
+    "Raw health samples, raw workouts, route streams, laps, and metadata JSON are intentionally excluded from this LLM bundle.",
+    ...snapshot.sourceFreshness.flatMap((source) => source.limitations),
+    ...snapshot.trainingLoad.limitations,
+  ];
+}
+
+export function buildLlmBundle(
+  snapshot: PipelineSnapshot,
+  options: LlmBundleOptions = {},
+): LlmBundle {
+  const exportedAt = isoString(options.exportedAt);
+  const goalProfile = options.goalProfile ?? null;
+  const readiness = snapshot.recommendation.readinessStatus;
+  const riskFlags =
+    options.riskFlags ??
+    extractRiskFlagsFromCoachRequest({
+      generated_at: exportedAt,
+      goal_profile: goalProfile ?? undefined,
+      daily_check_in: options.currentCheckIn ?? undefined,
+    });
+
+  return {
+    schema: "biostream_llm_bundle.v1",
+    exportedAt,
+    currentState: {
+      date: snapshot.today?.date ?? null,
+      readiness: {
+        score: snapshot.recommendation.readiness,
+        status: readiness.status,
+        confidence: readiness.confidence,
+        summary: readiness.ui.reason,
+        signalsUsed: readiness.signalsUsed,
+        missingSignals: readiness.missingSignals,
+        staleSignalsIgnored: readiness.staleSignalsIgnored,
+      },
+      today: snapshot.today ? compactDailyMetrics(snapshot.today) : null,
+      recommendation: {
+        title: snapshot.recommendation.title,
+        detail: snapshot.recommendation.detail,
+        reason: snapshot.recommendation.reason,
+        shortExplanation: snapshot.recommendation.shortExplanation,
+        recommendedActivity: snapshot.recommendation.recommendedActivity,
+        easierAlternative: snapshot.recommendation.easierAlternative,
+        whatToAvoidToday: snapshot.recommendation.whatToAvoidToday,
+        confidence: snapshot.recommendation.confidence,
+        sourcesUsed: snapshot.recommendation.sourcesUsed,
+        sourcesIgnored: snapshot.recommendation.sourcesIgnored,
+        checkInQuestion: snapshot.recommendation.checkInQuestion,
+      },
+      trainingLoad: toTrainingLoadExport(snapshot.trainingLoad),
+    },
+    recentHistory: snapshot.history.slice(0, 14).map(compactDailyMetrics),
+    goalProfile,
+    eventProfile: {
+      eventIntent: goalProfile?.primaryGoal === "event_preparation",
+      timeframe: goalProfile?.timeframe ?? null,
+      preferredActivities: goalProfile?.preferredActivities ?? [],
+      constraints: goalProfile?.constraints ?? [],
+      confidence: goalProfile?.confidence ?? 0,
+    },
+    dailyCheckIn: {
+      currentCheckIn: options.currentCheckIn ?? null,
+      checkInHistory: options.checkInHistory ?? [],
+    },
+    sourceFreshness: snapshot.sourceFreshness.map(toBundleSource),
+    riskFlags,
+    dataLimitations: Array.from(new Set(dataLimitations(snapshot))),
+  };
+}

--- a/src/export/pipelineExport.test.ts
+++ b/src/export/pipelineExport.test.ts
@@ -51,6 +51,10 @@ describe("buildPipelineExportArtifacts", () => {
 
     expect(artifacts.jsonFileName).toBe("biostream-pipeline-123.json");
     expect(artifacts.healthCheckFileName).toBe("health_check-123.md");
+    expect(artifacts.llmBundleFileName).toBe("llm_bundle-123.json");
+    expect(artifacts.llmBundleJson).toContain(
+      '"schema":"biostream_llm_bundle.v1"',
+    );
     expect(artifacts.healthCheckMarkdown).toContain(
       "Generated at: 2026-04-29T05:00:00.000Z",
     );

--- a/src/export/pipelineExport.ts
+++ b/src/export/pipelineExport.ts
@@ -1,16 +1,21 @@
 import type { PipelineSnapshot } from "../health/types";
+import { safeJsonStringify } from "../lib/json";
 import { generateHealthCheckMarkdown } from "./healthCheck";
+import { buildLlmBundle, type LlmBundleOptions } from "./llmBundle";
 
 export type PipelineExportArtifactOptions = {
   exportedAt?: string | Date;
   timestamp?: number;
+  llmBundle?: LlmBundleOptions;
 };
 
 export type PipelineExportArtifacts = {
   exportedAt: string;
   jsonFileName: string;
   healthCheckFileName: string;
+  llmBundleFileName: string;
   healthCheckMarkdown: string;
+  llmBundleJson: string;
 };
 
 function isoString(value: string | Date | undefined): string {
@@ -32,8 +37,15 @@ export function buildPipelineExportArtifacts(
     exportedAt,
     jsonFileName: `biostream-pipeline-${timestamp}.json`,
     healthCheckFileName: `health_check-${timestamp}.md`,
+    llmBundleFileName: `llm_bundle-${timestamp}.json`,
     healthCheckMarkdown: generateHealthCheckMarkdown(snapshot, {
       generatedAt: exportedAt,
     }),
+    llmBundleJson: safeJsonStringify(
+      buildLlmBundle(snapshot, {
+        ...options.llmBundle,
+        exportedAt,
+      }),
+    ),
   };
 }

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -63,6 +63,7 @@ export type SourceFreshness = {
   canonicalTypes: CanonicalType[];
   sampleCount: number;
   dayCount: number;
+  earliestLocalDate?: string;
   latestLocalDate?: string;
   lastUpdatedAt?: string;
   ageDays?: number;

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -178,6 +178,7 @@ type MetricAvailabilityRow = {
 type FreshnessStatsRow = {
   sample_count: number | null;
   day_count: number | null;
+  first_date: string | null;
   latest_date: string | null;
   last_updated_at: string | null;
 };
@@ -831,6 +832,7 @@ async function freshnessStatsForSamples(
       SELECT
         COUNT(*) AS sample_count,
         COUNT(DISTINCT local_date) AS day_count,
+        MIN(local_date) AS first_date,
         MAX(local_date) AS latest_date,
         MAX(COALESCE(source_modified_at, end_at, imported_at)) AS last_updated_at
       FROM health_samples
@@ -847,6 +849,7 @@ async function freshnessStatsForSleep(
     SELECT
       COUNT(*) AS sample_count,
       COUNT(DISTINCT date_key) AS day_count,
+      MIN(date_key) AS first_date,
       MAX(date_key) AS latest_date,
       MAX(updated_at) AS last_updated_at
     FROM (
@@ -867,6 +870,7 @@ async function freshnessStatsForWorkouts(
     SELECT
       COUNT(*) AS sample_count,
       COUNT(DISTINCT date_key) AS day_count,
+      MIN(date_key) AS first_date,
       MAX(date_key) AS latest_date,
       MAX(updated_at) AS last_updated_at
     FROM (
@@ -912,6 +916,7 @@ async function freshnessStatsForNutrition(
     SELECT
       COUNT(*) AS sample_count,
       COUNT(DISTINCT date_key) AS day_count,
+      MIN(date_key) AS first_date,
       MAX(date_key) AS latest_date,
       MAX(updated_at) AS last_updated_at
     FROM (
@@ -1156,6 +1161,7 @@ async function getSourceFreshness(
     );
     const sampleCount = Number(stats?.sample_count ?? 0);
     const dayCount = Number(stats?.day_count ?? 0);
+    const earliestDate = stats?.first_date ?? undefined;
     const latestDate = stats?.latest_date ?? undefined;
     const ageDays = daysSinceLocalDate(latestDate, today);
     const missingTypes =
@@ -1198,6 +1204,7 @@ async function getSourceFreshness(
       canonicalTypes: config.canonicalTypes,
       sampleCount,
       dayCount,
+      earliestLocalDate: earliestDate,
       latestLocalDate: latestDate,
       lastUpdatedAt: stats?.last_updated_at ?? undefined,
       ageDays,
@@ -1209,11 +1216,13 @@ async function getSourceFreshness(
     SELECT
       COUNT(*) AS sample_count,
       COUNT(DISTINCT local_date) AS day_count,
+      MIN(local_date) AS first_date,
       MAX(local_date) AS latest_date,
       MAX(updated_at) AS last_updated_at
     FROM daily_check_ins
   `);
   const checkInCount = Number(checkInStats?.sample_count ?? 0);
+  const checkInEarliestDate = checkInStats?.first_date ?? undefined;
   const checkInLatestDate = checkInStats?.latest_date ?? undefined;
   const checkInAgeDays = daysSinceLocalDate(checkInLatestDate, today);
   rows.push({
@@ -1227,6 +1236,7 @@ async function getSourceFreshness(
     canonicalTypes: [],
     sampleCount: checkInCount,
     dayCount: Number(checkInStats?.day_count ?? 0),
+    earliestLocalDate: checkInEarliestDate,
     latestLocalDate: checkInLatestDate,
     lastUpdatedAt: checkInStats?.last_updated_at ?? undefined,
     ageDays: checkInAgeDays,

--- a/src/storage/trainingStore.ts
+++ b/src/storage/trainingStore.ts
@@ -155,6 +155,7 @@ export type SyncRunDetails = {
 export type PipelineExportResult = {
   jsonFileUri: string;
   healthCheckFileUri: string;
+  llmBundleFileUri: string;
 };
 
 type HealthConnectDiagnosticRow = {
@@ -3385,13 +3386,21 @@ export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
     const goalProfileRow = await db.getFirstAsync<GoalProfileRow>(
       "SELECT * FROM goal_profile WHERE id = 'current' LIMIT 1",
     );
-    const exportArtifacts = buildPipelineExportArtifacts(pipelineSnapshot);
-    const exportedAt = exportArtifacts.exportedAt;
+    const exportedAt = new Date().toISOString();
+    const timestamp = Date.now();
     const goalProfile = goalProfileRow ? toGoalProfile(goalProfileRow) : null;
     const riskFlags = extractRiskFlagsFromCoachRequest({
       generated_at: exportedAt,
       goal_profile: goalProfile ?? undefined,
       daily_check_in: pipelineSnapshot.todayCheckIn ?? undefined,
+    });
+    const exportArtifacts = buildPipelineExportArtifacts(pipelineSnapshot, {
+      exportedAt,
+      timestamp,
+      llmBundle: {
+        goalProfile,
+        riskFlags,
+      },
     });
 
     const payload = {
@@ -3420,10 +3429,18 @@ export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
 
     const jsonFileUri = `${directory}${exportArtifacts.jsonFileName}`;
     const healthCheckFileUri = `${directory}${exportArtifacts.healthCheckFileName}`;
+    const llmBundleFileUri = `${directory}${exportArtifacts.llmBundleFileName}`;
     await Promise.all([
       FileSystem.writeAsStringAsync(jsonFileUri, safeJsonStringify(payload), {
         encoding: FileSystem.EncodingType.UTF8,
       }),
+      FileSystem.writeAsStringAsync(
+        llmBundleFileUri,
+        exportArtifacts.llmBundleJson,
+        {
+          encoding: FileSystem.EncodingType.UTF8,
+        },
+      ),
       FileSystem.writeAsStringAsync(
         healthCheckFileUri,
         exportArtifacts.healthCheckMarkdown,
@@ -3442,9 +3459,13 @@ export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
         mimeType: "text/markdown",
         dialogTitle: "Export BioStream health_check.md",
       });
+      await Sharing.shareAsync(llmBundleFileUri, {
+        mimeType: "application/json",
+        dialogTitle: "Export BioStream llm_bundle.json",
+      });
     }
 
-    return { jsonFileUri, healthCheckFileUri };
+    return { jsonFileUri, healthCheckFileUri, llmBundleFileUri };
   });
 }
 

--- a/src/storage/trainingStore.web.ts
+++ b/src/storage/trainingStore.web.ts
@@ -102,6 +102,7 @@ export type SyncRunDetails = {
 export type PipelineExportResult = {
   jsonFileUri: string;
   healthCheckFileUri: string;
+  llmBundleFileUri: string;
 };
 
 const dayMs = 24 * 60 * 60 * 1000;
@@ -203,6 +204,7 @@ function daysSinceLocalDate(localDate: string | undefined): number | undefined {
 
 function checkInSourceFreshness(checkIns: DailyCheckIn[]): SourceFreshness {
   const latest = checkIns[0];
+  const earliest = checkIns[checkIns.length - 1];
   const latestLocalDate = latest?.localDate;
   const ageDays = daysSinceLocalDate(latestLocalDate);
 
@@ -217,6 +219,7 @@ function checkInSourceFreshness(checkIns: DailyCheckIn[]): SourceFreshness {
     canonicalTypes: [],
     sampleCount: checkIns.length,
     dayCount: new Set(checkIns.map((checkIn) => checkIn.localDate)).size,
+    earliestLocalDate: earliest?.localDate,
     latestLocalDate,
     lastUpdatedAt: latest?.updatedAt,
     ageDays,
@@ -881,6 +884,7 @@ export async function exportPipelineArtifacts(): Promise<PipelineExportResult> {
   return {
     jsonFileUri: `web-demo://${artifacts.jsonFileName}`,
     healthCheckFileUri: `web-demo://${artifacts.healthCheckFileName}`,
+    llmBundleFileUri: `web-demo://${artifacts.llmBundleFileName}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add compact `llm_bundle.json` generation with current state, recent history, goals, event profile, daily check-in, source freshness, risk flags, training load, and data limitations.
- Wire native and web exports to include `llm_bundle-<timestamp>.json` / `llmBundleFileUri`.
- Preserve raw records out of the bundle, use real source date ranges where available, and allowlist daily check-in fields to the #24 schema before risk extraction.

## Test Plan
- npm test -- --runInBand src/export/llmBundle.test.ts src/export/pipelineExport.test.ts src/storage/trainingStore.web.test.ts
- npm run typecheck
- git diff --check origin/main..HEAD

Fixes #21